### PR TITLE
Add clone impl to filters

### DIFF
--- a/src/dto/core/asset/filter.rs
+++ b/src/dto/core/asset/filter.rs
@@ -72,7 +72,7 @@ pub struct FilterAssetsRequest {
     pub partition: Option<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AssetQuery {
     pub limit: Option<i32>,
     pub cursor: Option<String>,

--- a/src/dto/core/datapoint/filter.rs
+++ b/src/dto/core/datapoint/filter.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Identity;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Aggregate {
     Average,
@@ -23,7 +23,7 @@ impl From<&str> for Aggregate {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DatapointsFilter {
     pub items: Vec<DatapointsQuery>,
@@ -43,7 +43,7 @@ pub struct DatapointsFilter {
     pub ignore_unknown_ids: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DatapointsQuery {
     #[serde(flatten)]
@@ -76,7 +76,7 @@ impl Default for DatapointsQuery {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LatestDatapointsQuery {
     pub before: String,
@@ -93,7 +93,7 @@ impl LatestDatapointsQuery {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteDatapointsQuery {
     pub inclusive_begin: i64,

--- a/src/dto/core/event/filter.rs
+++ b/src/dto/core/event/filter.rs
@@ -5,7 +5,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct EventQuery {
     pub limit: Option<i32>,
     pub cursor: Option<String>,
@@ -150,7 +150,7 @@ impl EventFilter {
     }
 }
 
-#[derive(Serialize, Debug, Default)]
+#[derive(Serialize, Debug, Default, Clone)]
 pub struct EventFilterQuery {
     pub filter: EventFilter,
     pub limit: Option<i32>,
@@ -177,7 +177,7 @@ impl WithPartition for EventFilterQuery {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AggregatedEventsCountFilter {
     pub filter: EventFilter,
@@ -189,7 +189,7 @@ impl AggregatedEventsCountFilter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AggregatedEventsListFilter {
     pub filter: EventFilter,
@@ -211,7 +211,7 @@ impl AggregatedEventsListFilter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSearch {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/dto/core/files/filter.rs
+++ b/src/dto/core/files/filter.rs
@@ -1,7 +1,7 @@
 use crate::{AsParams, Identity, LabelsFilter, Range};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FileFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,7 +46,7 @@ impl FileFilter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FileSearch {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/dto/core/sequences.rs
+++ b/src/dto/core/sequences.rs
@@ -174,7 +174,7 @@ impl From<&AddSequence> for PatchSequence {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -197,7 +197,7 @@ pub struct SequenceFilter {
     pub data_set_ids: Option<Vec<Identity>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,7 +259,7 @@ pub struct InsertSequenceRows {
     pub id: Identity,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveSequenceRows {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/dto/core/time_serie/filter.rs
+++ b/src/dto/core/time_serie/filter.rs
@@ -3,7 +3,7 @@ use crate::{AsParams, Range};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeSerieFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,7 +40,7 @@ impl TimeSerieFilter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeSerieSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +57,7 @@ impl TimeSerieSearch {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TimeSerieQuery {
     pub limit: Option<i32>,
     pub include_metadata: Option<bool>,

--- a/src/dto/data_ingestion/extpipes.rs
+++ b/src/dto/data_ingestion/extpipes.rs
@@ -146,7 +146,7 @@ impl From<&AddExtPipe> for PatchExtPipe {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ExtPipeRunStatus {
     Success,
@@ -160,7 +160,7 @@ impl Default for ExtPipeRunStatus {
     }
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct ExtPipeFilter {
     pub external_id_prefix: Option<String>,
     pub name: Option<String>,
@@ -198,13 +198,13 @@ pub struct AddExtPipeRun {
     pub external_id: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeStringFilter {
     pub substring: String,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeRunFilter {
     pub external_id: String,

--- a/src/dto/data_ingestion/raw.rs
+++ b/src/dto/data_ingestion/raw.rs
@@ -40,7 +40,7 @@ pub struct DeleteRow {
     pub key: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct RetrieveCursorsQuery {
     pub min_last_updated_time: Option<i64>,
     pub max_last_updated_time: Option<i64>,
@@ -65,7 +65,7 @@ impl AsParams for RetrieveCursorsQuery {
     }
 }
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, Serialize, Clone)]
 pub struct RetrieveRowsQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,

--- a/src/dto/data_organization/datasets.rs
+++ b/src/dto/data_organization/datasets.rs
@@ -39,7 +39,7 @@ impl From<&DataSet> for AddDataSet {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataSetFilter {
     pub metadata: Option<HashMap<String, String>>,

--- a/src/dto/data_organization/labels.rs
+++ b/src/dto/data_organization/labels.rs
@@ -32,7 +32,7 @@ impl From<&Label> for AddLabel {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelFilter {
     pub name: Option<String>,

--- a/src/dto/data_organization/relationships.rs
+++ b/src/dto/data_organization/relationships.rs
@@ -161,7 +161,7 @@ impl From<&AddRelationship> for PatchRelationship {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveRelationshipsRequest {
     pub items: ::serde_json::Value,
@@ -214,7 +214,7 @@ pub struct RelationshipsFilter {
     pub labels: Option<LabelsFilter>,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterRelationshipsQuery {
     pub filter: RelationshipsFilter,

--- a/src/dto/filter_types.rs
+++ b/src/dto/filter_types.rs
@@ -19,7 +19,7 @@ impl<T> Range<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Filter<T> {
     pub filter: T,
@@ -45,7 +45,7 @@ impl<T> SetCursor for Filter<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Search<TFilter, TSearch> {
     pub filter: TFilter,
@@ -71,7 +71,7 @@ pub enum LabelsFilter {
     ContainsAll(Vec<CogniteExternalId>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Partition {
     pub num_partitions: u32,
     pub partition_number: u32,
@@ -101,7 +101,7 @@ impl Serialize for Partition {
     }
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PartitionedFilter<T> {
     pub filter: T,


### PR DESCRIPTION
This is handy in some cases, for things like partitioned reads.

In general, the cost of adding a clone impl like this is a bit of compilation time (very little), and of course the runtime cost if you actually use it. For filters, however, the cost of using them is generally negligible compared to the cost of the request itself.