### PR TITLE
Add AuthTicket to AuthHeaderManager

### DIFF
--- a/src/api/authenticator.rs
+++ b/src/api/authenticator.rs
@@ -15,6 +15,7 @@ pub enum AuthHeaderManager {
     OIDCToken(Authenticator),
     ApiKey(String),
     FixedToken(String),
+    AuthTicket(String),
     Custom(Box<CustomAuthCallback>),
 }
 
@@ -52,6 +53,15 @@ impl AuthHeaderManager {
                         error_uri: None,
                     })?;
                 headers.insert("Authorization", auth_header_value);
+            }
+            AuthHeaderManager::AuthTicket(t) => {
+                let auth_ticket_header_value =
+                    HeaderValue::from_str(t).map_err(|e| AuthenticatorError {
+                        error: Some(format!("Failed to set auth ticket: {}", e)),
+                        error_description: None,
+                        error_uri: None,
+                    })?;
+                headers.insert("auth-ticket", auth_ticket_header_value);
             }
             AuthHeaderManager::Custom(c) => c(headers, client),
         }


### PR DESCRIPTION
We are using auth tickets to authenticate with CDF in robotics-services. This PR adds AuthTicket explicitly to the AuthHeaderManager, enabling us to easily and explicitly add the auth ticket as a header.  `Custom(Box<CustomAuthCallback>)` requires static strings, meaning that we could not directly set the headerValue from the ticket (which had a shorter lifetime). 

Tested locally and in the cloud on our robotics project (greenfield) (setup with `new_custom_auth`). 