### PR TITLE
Refactor missing and duplicated

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,5 +7,6 @@ pub mod data_ingestion;
 pub mod data_organization;
 pub mod iam;
 pub mod resource;
+pub mod utils;
 
 pub use self::api_client::*;

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -1,0 +1,25 @@
+use crate::{Identity, Kind, Result};
+
+pub fn get_duplicates_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
+    match res {
+        Ok(_) => None,
+        Err(e) => match &e.kind {
+            Kind::Conflict(c) => c
+                .duplicated
+                .as_ref()
+                .map(|dup| dup.get_identities().collect()),
+            _ => None,
+        },
+    }
+}
+
+pub fn get_missing_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
+    match res {
+        Ok(_) => None,
+        Err(e) => match &e.kind {
+            Kind::BadRequest(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
+            Kind::NotFound(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
+            _ => None,
+        },
+    }
+}

--- a/src/dto/core/event/mod.rs
+++ b/src/dto/core/event/mod.rs
@@ -2,7 +2,7 @@ mod filter;
 
 pub use self::filter::*;
 
-use crate::{EqIdentity, Identity, Patch, UpdateList, UpdateMap, UpdateSetNull};
+use crate::{EqIdentity, Identity, IntegerOrString, Patch, UpdateList, UpdateMap, UpdateSetNull};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -12,13 +12,6 @@ pub struct EventListResponse {
     pub items: Vec<Event>,
     previous_cursor: Option<String>,
     next_cursor: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum IntegerOrString {
-    Integer(i64),
-    String(String),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod iam {
 }
 
 pub use self::{
-    api::{api_client::*, authenticator::*, resource::*},
+    api::{api_client::*, authenticator::*, resource::*, utils::*},
     cognite_client::*,
     dto::{filter_types::*, identity::*, items::*, params::*, patch_item::*},
     error::*,


### PR DESCRIPTION
Part of the issue is that we were assuming the response was string, which is not universally the case. Use `IntegerOrString` instead, which is more generic. Also pull logic for getting missing/duplicated out of resources.rs.

This is a bit tidier, and we can reuse the code for fetching duplicates/missing entries elsewhere.