### PR TITLE
Support for configured retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ async-trait = { version = "0.1.53" }
 futures = "0.3.24"
 thiserror = "1.0"
 bytes = "1.2.1"
+reqwest-middleware = "0.2.0"
+task-local-extensions = "0.1.3"
+futures-timer = "3.0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,6 +2,7 @@ use cognite::assets::*;
 use cognite::events::*;
 use cognite::files::*;
 use cognite::time_series::*;
+use cognite::ClientConfig;
 use cognite::FilterItems;
 use cognite::FilterWithRequest;
 use cognite::List;
@@ -9,7 +10,14 @@ use cognite::{CogniteClient, Identity, SearchItems};
 
 #[tokio::main]
 async fn main() {
-    let cognite_client = CogniteClient::new("TestApp").unwrap();
+    let cognite_client = CogniteClient::new(
+        "TestApp",
+        Some(ClientConfig {
+            max_retries: 5,
+            ..Default::default()
+        }),
+    )
+    .unwrap();
     // List all assets
     let mut filter: AssetFilter = AssetFilter::new();
     filter.name.replace("Aker".to_string());

--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -3,7 +3,9 @@ use crate::{AsParams, AuthHeaderManager};
 use futures::{Stream, TryStreamExt};
 use prost::Message;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, USER_AGENT};
-use reqwest::{Body, Client, RequestBuilder, Response, StatusCode};
+use reqwest::{Body, Response, StatusCode};
+use reqwest_middleware::ClientWithMiddleware;
+use reqwest_middleware::RequestBuilder;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
@@ -12,14 +14,19 @@ use crate::error::{Error, Result};
 pub struct ApiClient {
     api_base_url: String,
     app_name: String,
-    client: Client,
+    client: ClientWithMiddleware,
     authenticator: AuthHeaderManager,
 }
 
 const SDK_VERSION: &str = concat!("rust-sdk-v", env!("CARGO_PKG_VERSION"));
 
 impl ApiClient {
-    pub fn new(api_base_url: &str, api_key: &str, app_name: &str, client: Client) -> ApiClient {
+    pub fn new(
+        api_base_url: &str,
+        api_key: &str,
+        app_name: &str,
+        client: ClientWithMiddleware,
+    ) -> ApiClient {
         ApiClient {
             api_base_url: String::from(api_base_url),
             app_name: String::from(app_name),
@@ -32,7 +39,7 @@ impl ApiClient {
         api_base_url: &str,
         auth: Authenticator,
         app_name: &str,
-        client: Client,
+        client: ClientWithMiddleware,
     ) -> ApiClient {
         ApiClient {
             api_base_url: String::from(api_base_url),
@@ -46,7 +53,7 @@ impl ApiClient {
         api_base_url: &str,
         auth: AuthHeaderManager,
         app_name: &str,
-        client: Client,
+        client: ClientWithMiddleware,
     ) -> ApiClient {
         ApiClient {
             api_base_url: String::from(api_base_url),

--- a/src/error.rs
+++ b/src/error.rs
@@ -197,6 +197,8 @@ pub enum Kind {
     IOError(std::io::Error),
     #[error("Error collecting stream: {0}")]
     StreamError(String),
+    #[error("Error in middleware: {0}")]
+    Middleware(String),
 }
 
 #[derive(Debug, Error)]
@@ -274,5 +276,14 @@ impl From<std::io::Error> for Kind {
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::new(Kind::from(err))
+    }
+}
+
+impl From<reqwest_middleware::Error> for Error {
+    fn from(err: reqwest_middleware::Error) -> Self {
+        match err {
+            reqwest_middleware::Error::Middleware(x) => Error::new(Kind::Middleware(x.to_string())),
+            reqwest_middleware::Error::Reqwest(x) => Self::from(x),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod cognite_client;
 mod api;
 mod dto;
 mod error;
+mod retry;
 
 pub mod login {
     pub use super::api::auth::login::*;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,130 @@
+// This file is adapted from reqwest-retry, which was a bit too opinionated for our use.
+// https://github.com/TrueLayer/reqwest-middleware
+
+use async_trait::async_trait;
+use reqwest::{Request, Response, StatusCode};
+use reqwest_middleware::{Middleware, Next, Result};
+use std::time::Duration;
+use task_local_extensions::Extensions;
+
+pub struct CustomRetryMiddleware {
+    max_retries: u32,
+    max_delay_ms: u64,
+}
+
+#[async_trait]
+impl Middleware for CustomRetryMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        self.execute_with_retry(req, next, extensions).await
+    }
+}
+
+impl CustomRetryMiddleware {
+    pub fn new(max_retries: u32, max_delay_ms: u64) -> Self {
+        Self {
+            max_retries: max_retries.min(10),
+            max_delay_ms,
+        }
+    }
+
+    async fn execute_with_retry<'a>(
+        &'a self,
+        req: Request,
+        next: Next<'a>,
+        ext: &'a mut Extensions,
+    ) -> Result<Response> {
+        let mut n_past_retries = 0;
+        loop {
+            let duplicate_request = match req.try_clone() {
+                Some(x) => x,
+                None => return next.run(req, ext).await,
+            };
+
+            let result = next.clone().run(duplicate_request, ext).await;
+
+            // We classify the response which will return None if not
+            // errors were returned.
+            break match Retryable::from_reqwest_response(&result) {
+                Some(retryable)
+                    if retryable == Retryable::Transient && n_past_retries < self.max_retries =>
+                {
+                    // If the response failed and the error type was transient
+                    // we can safely try to retry the request.
+                    let mut retry_delay = 125u64 * 2u64.pow(n_past_retries);
+                    if retry_delay > self.max_delay_ms {
+                        retry_delay = self.max_delay_ms;
+                    }
+                    futures_timer::Delay::new(Duration::from_millis(retry_delay)).await;
+                    n_past_retries += 1;
+                    continue;
+                }
+                Some(_) | None => result,
+            };
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum Retryable {
+    /// The failure was due to something tha might resolve in the future.
+    Transient,
+    /// Unresolvable error.
+    Fatal,
+}
+
+impl Retryable {
+    /// Try to map a `reqwest` response into `Retryable`.
+    ///
+    /// Returns `None` if the response object does not contain any errors.
+    ///
+    pub fn from_reqwest_response(
+        res: &reqwest_middleware::Result<reqwest::Response>,
+    ) -> Option<Self> {
+        match res {
+            Ok(success) => {
+                let status = success.status();
+                if status.is_server_error() {
+                    Some(Retryable::Transient)
+                } else if status.is_client_error()
+                    && status != StatusCode::REQUEST_TIMEOUT
+                    && status != StatusCode::TOO_MANY_REQUESTS
+                {
+                    Some(Retryable::Fatal)
+                } else if status.is_success() {
+                    None
+                } else if status == StatusCode::REQUEST_TIMEOUT
+                    || status == StatusCode::TOO_MANY_REQUESTS
+                {
+                    Some(Retryable::Transient)
+                } else {
+                    Some(Retryable::Fatal)
+                }
+            }
+            Err(error) => match error {
+                reqwest_middleware::Error::Middleware(_) => Some(Retryable::Fatal),
+                reqwest_middleware::Error::Reqwest(error) => {
+                    if error.is_timeout() || error.is_connect() {
+                        Some(Retryable::Transient)
+                    } else if error.is_body()
+                        || error.is_decode()
+                        || error.is_builder()
+                        || error.is_redirect()
+                        || error.is_request()
+                    {
+                        Some(Retryable::Fatal)
+                    } else {
+                        // We omit checking if error.is_status() since we check that already.
+                        // However, if Response::error_for_status is used the status will still
+                        // remain in the response object.
+                        None
+                    }
+                }
+            },
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,16 @@ use rand::{distributions::Alphanumeric, Rng};
 
 #[cfg(test)]
 pub fn get_client() -> CogniteClient {
-    CogniteClient::new_oidc("rust_sdk_test").unwrap()
+    use cognite::ClientConfig;
+
+    CogniteClient::new_oidc(
+        "rust_sdk_test",
+        Some(ClientConfig {
+            max_retries: 5,
+            ..Default::default()
+        }),
+    )
+    .unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ended up modifying the version from reqwest-middleware, since it pulls in tokio and fails if you try to pass a stream, we would like to just ignore those, for now.