### PR TITLE
Auth middleware

### DIFF
--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::Display,
     time::{SystemTime, UNIX_EPOCH},
 };
+use thiserror::Error;
 
 type CustomAuthCallback = dyn Fn(&mut HeaderMap, &ClientWithMiddleware) + Send + Sync;
 
@@ -112,7 +113,7 @@ struct AuthenticatorResponse {
     expires_in: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Error)]
 pub struct AuthenticatorError {
     pub error: Option<String>,
     pub error_description: Option<String>,

--- a/cognite/src/auth.rs
+++ b/cognite/src/auth.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use reqwest::{Request, Response};
+use reqwest_middleware::{ClientWithMiddleware, Middleware, Next, Result};
+use task_local_extensions::Extensions;
+
+use crate::AuthHeaderManager;
+
+pub struct AuthenticatorMiddleware {
+    authenticator: AuthHeaderManager,
+}
+
+struct AuthenticatorFlag;
+
+impl AuthenticatorMiddleware {
+    pub fn new(authenticator: AuthHeaderManager) -> crate::Result<Self> {
+        Ok(Self { authenticator })
+    }
+}
+
+#[async_trait]
+impl Middleware for AuthenticatorMiddleware {
+    async fn handle(
+        &self,
+        mut req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        // Since we are reusing the client, we want to avoid infinitely calling the authenticator recursively,
+        // so we add a flag indicating that we have already called the authenticator in this chain.
+        if !extensions.contains::<AuthenticatorFlag>() {
+            // Add the flag before we call the authenticator, this prevents the authenticator from
+            // attempting to add headers to its own request, which would deadlock.
+            extensions.insert(AuthenticatorFlag);
+            // This is all a little hacky, we add the client itself as an extension to the request
+            // so that we can use it from in here. The deadlocky-ness of this is exactly why it isn't
+            // possible by default.
+            // If it isn't in there we assume that it isn't supposed to be there, and skip the whole layer.
+            if let Some(client) = extensions.get::<ClientWithMiddleware>() {
+                self.authenticator
+                    .set_headers(req.headers_mut(), client)
+                    .await
+                    .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?;
+            }
+            // Once we're done, remove the flag
+            extensions.remove::<AuthenticatorFlag>();
+        }
+        next.run(req, extensions).await
+    }
+}

--- a/cognite/src/lib.rs
+++ b/cognite/src/lib.rs
@@ -1,6 +1,7 @@
 mod cognite_client;
 
 mod api;
+mod auth;
 mod dto;
 mod error;
 mod retry;


### PR DESCRIPTION
Add the authenticator to middleware instead of appending it on each request.

This has the advantage of letting us retry 401s sometimes, which is useful.