### PR TITLE
Client builder

### DIFF
--- a/cognite/src/error.rs
+++ b/cognite/src/error.rs
@@ -199,6 +199,8 @@ pub enum Kind {
     StreamError(String),
     #[error("Error in middleware: {0}")]
     Middleware(String),
+    #[error("Error in configuration: {0}")]
+    Config(String),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
A slightly more flexible approach, to avoid constantly adding new constructors, or breaking existing constructors.

This PR also adds the ability to pass a reqwest client externally.