### PR TITLE
 Let custom auth return Results

### DIFF
--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -12,11 +12,16 @@ use std::{
 };
 use thiserror::Error;
 
-type CustomAuthCallback = dyn Fn(&mut HeaderMap, &ClientWithMiddleware) -> Result<(), AuthenticatorError> + Send + Sync;
+type CustomAuthCallback =
+    dyn Fn(&mut HeaderMap, &ClientWithMiddleware) -> Result<(), AuthenticatorError> + Send + Sync;
 
 #[async_trait]
 pub trait CustomAuthenticator {
-    async fn set_headers(&self, headers: &mut HeaderMap, client: &ClientWithMiddleware) -> Result<(), AuthenticatorError>;
+    async fn set_headers(
+        &self,
+        headers: &mut HeaderMap,
+        client: &ClientWithMiddleware,
+    ) -> Result<(), AuthenticatorError>;
 }
 
 pub enum AuthHeaderManager {

--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -12,11 +12,11 @@ use std::{
 };
 use thiserror::Error;
 
-type CustomAuthCallback = dyn Fn(&mut HeaderMap, &ClientWithMiddleware) + Send + Sync;
+type CustomAuthCallback = dyn Fn(&mut HeaderMap, &ClientWithMiddleware) -> Result<(), AuthenticatorError> + Send + Sync;
 
 #[async_trait]
 pub trait CustomAuthenticator {
-    async fn set_headers(&self, headers: &mut HeaderMap, client: &ClientWithMiddleware);
+    async fn set_headers(&self, headers: &mut HeaderMap, client: &ClientWithMiddleware) -> Result<(), AuthenticatorError>;
 }
 
 pub enum AuthHeaderManager {
@@ -76,8 +76,8 @@ impl AuthHeaderManager {
                     })?;
                 headers.insert("auth-ticket", auth_ticket_header_value);
             }
-            AuthHeaderManager::Custom(c) => c(headers, client),
-            AuthHeaderManager::CustomAsync(c) => c.set_headers(headers, client).await,
+            AuthHeaderManager::Custom(c) => c(headers, client)?,
+            AuthHeaderManager::CustomAsync(c) => c.set_headers(headers, client).await?,
         }
         Ok(())
     }


### PR DESCRIPTION
 This lets custom auth implementations report failures the same way the
 built-in ones do.