### PR TITLE
Fix new clippy warnings from 1.68

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 reqwest = { version = "0.11.14", features = ["json", "stream"] }
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
-uuid = { version = "1.3.0", features = ["serde", "v4"] }
 prost = "0.11.8"
 prost-types = "0.11.8"
 futures-locks = "0.7.1"

--- a/cognite/src/dto/core/sequences.rs
+++ b/cognite/src/dto/core/sequences.rs
@@ -5,8 +5,10 @@ use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum SequenceValueType {
     #[serde(rename = "DOUBLE")]
+    #[default]
     Double,
     #[serde(rename = "STRING")]
     String,
@@ -14,11 +16,7 @@ pub enum SequenceValueType {
     Long,
 }
 
-impl Default for SequenceValueType {
-    fn default() -> Self {
-        SequenceValueType::Double
-    }
-}
+
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]

--- a/cognite/src/dto/core/sequences.rs
+++ b/cognite/src/dto/core/sequences.rs
@@ -16,8 +16,6 @@ pub enum SequenceValueType {
     Long,
 }
 
-
-
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceColumn {

--- a/cognite/src/dto/data_organization/relationships.rs
+++ b/cognite/src/dto/data_organization/relationships.rs
@@ -10,7 +10,9 @@ use crate::{assets::Asset, events::Event, files::FileMetadata, time_series::Time
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub enum RelationshipVertexType {
+    #[default]
     Asset,
     TimeSeries,
     File,
@@ -20,11 +22,7 @@ pub enum RelationshipVertexType {
 
 // Want a default impl for AddRelationship, so we need a default value here
 // not ideal, really...
-impl Default for RelationshipVertexType {
-    fn default() -> Self {
-        RelationshipVertexType::Asset
-    }
-}
+
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", untagged)]

--- a/cognite/src/dto/data_organization/relationships.rs
+++ b/cognite/src/dto/data_organization/relationships.rs
@@ -23,7 +23,6 @@ pub enum RelationshipVertexType {
 // Want a default impl for AddRelationship, so we need a default value here
 // not ideal, really...
 
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum RelationshipVertex {

--- a/cognite/src/dto/iam/security_category.rs
+++ b/cognite/src/dto/iam/security_category.rs
@@ -20,16 +20,14 @@ pub struct SecurityCategory {
 }
 
 #[derive(Debug)]
+#[derive(Default)]
 pub enum SecurityCategorySortEnum {
+    #[default]
     ASC,
     DESC,
 }
 
-impl Default for SecurityCategorySortEnum {
-    fn default() -> Self {
-        SecurityCategorySortEnum::ASC
-    }
-}
+
 
 impl Display for SecurityCategorySortEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/cognite/src/dto/iam/security_category.rs
+++ b/cognite/src/dto/iam/security_category.rs
@@ -19,15 +19,12 @@ pub struct SecurityCategory {
     pub id: Option<u64>,
 }
 
-#[derive(Debug)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub enum SecurityCategorySortEnum {
     #[default]
     ASC,
     DESC,
 }
-
-
 
 impl Display for SecurityCategorySortEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
This is holding up the renovate PRs.

I also found that uuid was unused.