### PR TITLE
Add models/instances endpoints

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.11.14", features = ["json", "stream"] }
 reqwest-middleware = "0.2.1"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"
+serde_with = "2.3.1"
 task-local-extensions = "0.1.4"
 thiserror = "1.0.39"
 wiremock = "0.5.17"

--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -1,24 +1,30 @@
 [package]
-name = "cognite"
-version = "0.2.0"
-authors = ["Haakon Garseg Mørk <haakon.mork@cognite.com>", "Einar Marstrander Omang <einar.omang@cognite.com>"]
-publish = false
+authors = [
+    "Einar Marstrander Omang <einar.omang@cognite.com>",
+    "Haakon Garseg Mørk <haakon.mork@cognite.com>",
+    "Niek Beckers <niek.beckers@cognite.com>",
+]
 edition = "2018"
+name = "cognite"
+publish = false
+version = "0.2.1"
 
 [dependencies]
-reqwest = { version = "0.11.14", features = ["json", "stream"] }
-serde = { version = "1.0.156", features = ["derive"] }
-serde_json = "1.0.94"
+async-trait = "0.1.66"
+bytes = "1.4.0"
+derivative = "2.2.0"
+futures = "0.3.27"
+futures-locks = "0.7.1"
+futures-timer = "3.0.2"
 prost = "0.11.8"
 prost-types = "0.11.8"
-futures-locks = "0.7.1"
-async-trait = "0.1.66"
-futures = "0.3.27"
-thiserror = "1.0.39"
-bytes = "1.4.0"
+reqwest = { version = "0.11.14", features = ["json", "stream"] }
 reqwest-middleware = "0.2.1"
+serde = { version = "1.0.156", features = ["derive"] }
+serde_json = "1.0.94"
 task-local-extensions = "0.1.4"
-futures-timer = "3.0.2"
+thiserror = "1.0.39"
+wiremock = "0.5.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/cognite/src/api/data_modeling/instances.rs
+++ b/cognite/src/api/data_modeling/instances.rs
@@ -1,0 +1,32 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::dto::data_modeling::instances::{InstanceInfo, ListRequest, NodeOrEdge, SlimNodeOrEdge};
+use crate::models::{NodeAndEdgeCreateCollection, SpaceAndExternalId};
+use crate::{DeleteWithResponse, ItemsWithCursor, ListWithRequest, Retrieve, UpsertCollection};
+use crate::{Resource, WithBasePath};
+
+pub struct Instance {}
+pub type Instances = Resource<Instance>;
+
+impl WithBasePath for Instances {
+    const BASE_PATH: &'static str = "models/instances";
+}
+
+impl<TProperties> ListWithRequest<ItemsWithCursor<NodeOrEdge<TProperties>>, ListRequest>
+    for Instances
+where
+    TProperties: Serialize + DeserializeOwned + Sync + Send,
+{
+}
+impl<TProperties> Retrieve<InstanceInfo, NodeOrEdge<TProperties>> for Instances where
+    TProperties: Serialize + DeserializeOwned + Sync + Send
+{
+}
+impl<TProperties> UpsertCollection<NodeAndEdgeCreateCollection<TProperties>, SlimNodeOrEdge>
+    for Instances
+where
+    TProperties: Serialize + Sync + Send,
+{
+}
+impl DeleteWithResponse<InstanceInfo, SpaceAndExternalId> for Instances {}

--- a/cognite/src/api/data_modeling/instances.rs
+++ b/cognite/src/api/data_modeling/instances.rs
@@ -1,9 +1,11 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::dto::data_modeling::instances::{InstanceInfo, ListRequest, NodeOrEdge, SlimNodeOrEdge};
-use crate::models::{NodeAndEdgeCreateCollection, SpaceAndExternalId};
-use crate::{DeleteWithResponse, ItemsWithCursor, ListWithRequest, Retrieve, UpsertCollection};
+use crate::dto::data_modeling::instances::{InstanceInfo, NodeOrEdge, SlimNodeOrEdge};
+use crate::models::{InstanceId, InstancesFilter, NodeAndEdgeCreateCollection};
+use crate::{
+    DeleteWithResponse, Filter, FilterWithRequest, ItemsWithCursor, Retrieve, UpsertCollection,
+};
 use crate::{Resource, WithBasePath};
 
 pub struct Instance {}
@@ -13,7 +15,8 @@ impl WithBasePath for Instances {
     const BASE_PATH: &'static str = "models/instances";
 }
 
-impl<TProperties> ListWithRequest<ItemsWithCursor<NodeOrEdge<TProperties>>, ListRequest>
+impl<TProperties>
+    FilterWithRequest<Filter<InstancesFilter>, ItemsWithCursor<NodeOrEdge<TProperties>>>
     for Instances
 where
     TProperties: Serialize + DeserializeOwned + Sync + Send,
@@ -29,4 +32,4 @@ where
     TProperties: Serialize + Sync + Send,
 {
 }
-impl DeleteWithResponse<InstanceInfo, SpaceAndExternalId> for Instances {}
+impl DeleteWithResponse<InstanceInfo, InstanceId> for Instances {}

--- a/cognite/src/api/data_modeling/instances.rs
+++ b/cognite/src/api/data_modeling/instances.rs
@@ -2,9 +2,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::dto::data_modeling::instances::{NodeOrEdge, SlimNodeOrEdge};
-use crate::models::{
-    InstanceId, InstancesFilter, NodeAndEdgeCreateCollection, NodeOrEdgeSpecification,
-};
+use crate::models::{InstancesFilter, NodeAndEdgeCreateCollection, NodeOrEdgeSpecification};
 use crate::{
     DeleteWithResponse, Filter, FilterWithRequest, ItemsWithCursor, Retrieve, UpsertCollection,
 };
@@ -34,4 +32,4 @@ where
     TProperties: Serialize + Sync + Send,
 {
 }
-impl DeleteWithResponse<NodeOrEdgeSpecification, InstanceId> for Instances {}
+impl DeleteWithResponse<NodeOrEdgeSpecification, NodeOrEdgeSpecification> for Instances {}

--- a/cognite/src/api/data_modeling/instances.rs
+++ b/cognite/src/api/data_modeling/instances.rs
@@ -1,8 +1,10 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::dto::data_modeling::instances::{InstanceInfo, NodeOrEdge, SlimNodeOrEdge};
-use crate::models::{InstanceId, InstancesFilter, NodeAndEdgeCreateCollection};
+use crate::dto::data_modeling::instances::{NodeOrEdge, SlimNodeOrEdge};
+use crate::models::{
+    InstanceId, InstancesFilter, NodeAndEdgeCreateCollection, NodeOrEdgeSpecification,
+};
 use crate::{
     DeleteWithResponse, Filter, FilterWithRequest, ItemsWithCursor, Retrieve, UpsertCollection,
 };
@@ -22,7 +24,7 @@ where
     TProperties: Serialize + DeserializeOwned + Sync + Send,
 {
 }
-impl<TProperties> Retrieve<InstanceInfo, NodeOrEdge<TProperties>> for Instances where
+impl<TProperties> Retrieve<NodeOrEdgeSpecification, NodeOrEdge<TProperties>> for Instances where
     TProperties: Serialize + DeserializeOwned + Sync + Send
 {
 }
@@ -32,4 +34,4 @@ where
     TProperties: Serialize + Sync + Send,
 {
 }
-impl DeleteWithResponse<InstanceInfo, InstanceId> for Instances {}
+impl DeleteWithResponse<NodeOrEdgeSpecification, InstanceId> for Instances {}

--- a/cognite/src/api/data_modeling/mod.rs
+++ b/cognite/src/api/data_modeling/mod.rs
@@ -1,0 +1,17 @@
+pub mod instances;
+use std::sync::Arc;
+
+use crate::api::data_modeling::instances::Instances;
+use crate::ApiClient;
+
+pub struct Models {
+    pub instances: Instances,
+}
+
+impl Models {
+    pub fn new(api_client: Arc<ApiClient>) -> Self {
+        Models {
+            instances: Instances::new(api_client),
+        }
+    }
+}

--- a/cognite/src/api/mod.rs
+++ b/cognite/src/api/mod.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod authenticator;
 pub mod core;
 pub mod data_ingestion;
+pub mod data_modeling;
 pub mod data_organization;
 pub mod iam;
 pub mod resource;

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -56,21 +56,6 @@ where
 }
 
 #[async_trait]
-pub trait ListWithRequest<TResponse, TReq>
-where
-    TResponse: Serialize + DeserializeOwned + Send + Sync,
-    TReq: Serialize + DeserializeOwned + Send + Sync,
-    Self: WithApiClient + WithBasePath,
-{
-    async fn list(&self, req: &TReq) -> Result<ItemsWithCursor<TResponse>> {
-        Ok(self
-            .get_client()
-            .post(&format!("{}/list", Self::BASE_PATH), req)
-            .await?)
-    }
-}
-
-#[async_trait]
 pub trait Create<TCreate, TResponse>
 where
     TCreate: Serialize + Sync + Send,

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use super::{ApiClient, Error, Result};
 use crate::api::core::sequences::Sequences;
+use crate::api::data_modeling::Models;
 use crate::api::iam::sessions::Sessions;
 use crate::auth::AuthenticatorMiddleware;
 use crate::error::Kind;
@@ -75,6 +76,7 @@ pub struct CogniteClient {
     pub ext_pipe_runs: ExtPipeRuns,
     pub sequences: Sequences,
     pub sessions: Sessions,
+    pub models: Models,
 }
 
 static COGNITE_API_KEY: &str = "COGNITE_API_KEY";
@@ -192,7 +194,8 @@ impl CogniteClient {
             ext_pipes: ExtPipes::new(ac.clone()),
             ext_pipe_runs: ExtPipeRuns::new(ac.clone()),
             sequences: Sequences::new(ac.clone()),
-            sessions: Sessions::new(ac),
+            sessions: Sessions::new(ac.clone()),
+            models: Models::new(ac),
         })
     }
 

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -12,7 +12,7 @@ pub struct NodeAndEdgeCreateCollection<TProperties> {
     pub replace: Option<bool>,
 }
 
-impl Default for NodeAndEdgeCreateCollection<TProperties> {
+impl<TProperties> Default for NodeAndEdgeCreateCollection<TProperties> {
     fn default() -> Self {
         Self {
             items: vec![],

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -1,0 +1,170 @@
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize, Derivative, Clone)]
+pub struct NodeAndEdgeCreateCollection<TProperties> {
+    pub items: Vec<NodeOrEdgeCreate<TProperties>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[derivative(Default(value = "Some(false)"))]
+    pub auto_create_start_nodes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[derivative(Default(value = "Some(false)"))]
+    pub auto_create_end_nodes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[derivative(Default(value = "Some(false)"))]
+    pub skip_on_version_conflict: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[derivative(Default(value = "Some(false)"))]
+    pub replace: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum NodeOrEdgeCreate<TProperties> {
+    Node(NodeWrite<TProperties>),
+    Edge(EdgeWrite<TProperties>),
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum InstanceType {
+    #[default]
+    Node,
+    Edge,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListRequest {}
+
+#[derive(Serialize, Deserialize, Default, Derivative, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeWrite<TProperties> {
+    #[derivative(Default(value = "InstanceType::Node"))]
+    pub instance_type: InstanceType,
+    pub space: String,
+    pub external_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub existing_version: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Default, Derivative, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeWrite<TProperties> {
+    #[derivative(Default(value = "InstanceType::Edge"))]
+    pub instance_type: InstanceType,
+    pub space: String,
+    pub r#type: EdgeType,
+    pub external_id: String,
+    pub start_node: DirectRelationReference,
+    pub end_node: DirectRelationReference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub existing_version: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct EdgeOrNodeData<TProperties> {
+    pub source: SourceReference,
+    pub properties: TProperties,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceReference {
+    pub r#type: SourceReferenceType,
+    pub space: String,
+    pub external_id: String,
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceReferenceType {
+    View,
+    Container,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SlimNodeOrEdge {
+    pub instance_type: InstanceType,
+    pub space: String,
+    pub version: i64,
+    pub was_modified: bool,
+    pub external_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated_time: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Derivative)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeDefinition<TProperties> {
+    #[derivative(Default(value = "InstanceType::Node"))]
+    pub instance_type: InstanceType,
+    pub space: String,
+    pub version: String,
+    pub external_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<Vec<TProperties>>,
+    pub created_time: i64,
+    pub last_updated_time: i64,
+}
+
+#[derive(Serialize, Deserialize, Derivative)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeDefinition<TProperties> {
+    #[derivative(Default(value = "InstanceType::Edge"))]
+    pub instance_type: InstanceType,
+    pub space: String,
+    pub r#type: EdgeType,
+    pub version: String,
+    pub external_id: String,
+    pub created_time: i64,
+    pub last_updated_time: i64,
+    pub start_node: DirectRelationReference,
+    pub end_node: DirectRelationReference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<Vec<TProperties>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum NodeOrEdge<TProperties> {
+    Node(NodeDefinition<TProperties>),
+    Edge(EdgeDefinition<TProperties>),
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeType {
+    pub space: String,
+    pub external_id: String,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DirectRelationReference {
+    pub space: String,
+    pub external_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceInfo {
+    pub instance_type: InstanceType,
+    pub external_id: String,
+    pub space: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SpaceAndExternalId {
+    pub external_id: String,
+    pub space: String,
+}

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -2,20 +2,26 @@ use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Serialize, Deserialize, Derivative, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
 pub struct NodeAndEdgeCreateCollection<TProperties> {
     pub items: Vec<NodeOrEdgeCreate<TProperties>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[derivative(Default(value = "Some(false)"))]
     pub auto_create_start_nodes: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[derivative(Default(value = "Some(false)"))]
     pub auto_create_end_nodes: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[derivative(Default(value = "Some(false)"))]
     pub skip_on_version_conflict: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[derivative(Default(value = "Some(false)"))]
     pub replace: Option<bool>,
+}
+
+impl Default for NodeAndEdgeCreateCollection<TProperties> {
+    fn default() -> Self {
+        Self {
+            items: vec![],
+            auto_create_start_nodes: Some(false),
+            auto_create_end_nodes: Some(false),
+            skip_on_version_conflict: Some(false),
+            replace: Some(false),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -33,36 +39,30 @@ pub enum InstanceType {
     Edge,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ListRequest {}
-
 #[derive(Serialize, Deserialize, Default, Derivative, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
 pub struct NodeWrite<TProperties> {
     #[derivative(Default(value = "InstanceType::Node"))]
     pub instance_type: InstanceType,
     pub space: String,
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_version: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Default, Derivative, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
 pub struct EdgeWrite<TProperties> {
     #[derivative(Default(value = "InstanceType::Edge"))]
     pub instance_type: InstanceType,
     pub space: String,
-    pub r#type: EdgeType,
+    pub r#type: DirectRelationReference,
     pub external_id: String,
     pub start_node: DirectRelationReference,
     pub end_node: DirectRelationReference,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_version: Option<i64>,
 }
 
@@ -90,15 +90,14 @@ pub enum SourceReferenceType {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
 pub struct SlimNodeOrEdge {
     pub instance_type: InstanceType,
     pub space: String,
     pub version: i64,
     pub was_modified: bool,
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<i64>,
 }
 
@@ -122,7 +121,7 @@ pub struct EdgeDefinition<TProperties> {
     #[derivative(Default(value = "InstanceType::Edge"))]
     pub instance_type: InstanceType,
     pub space: String,
-    pub r#type: EdgeType,
+    pub r#type: DirectRelationReference,
     pub version: String,
     pub external_id: String,
     pub created_time: i64,
@@ -142,13 +141,6 @@ pub enum NodeOrEdge<TProperties> {
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct EdgeType {
-    pub space: String,
-    pub external_id: String,
-}
-
-#[derive(Serialize, Deserialize, Default, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct DirectRelationReference {
     pub space: String,
     pub external_id: String,
@@ -164,7 +156,14 @@ pub struct InstanceInfo {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct SpaceAndExternalId {
+pub struct InstanceId {
     pub external_id: String,
     pub space: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
+pub struct InstancesFilter {
+    // todo
 }

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -1,9 +1,10 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct NodeAndEdgeCreateCollection<TProperties> {
     pub items: Vec<NodeOrEdgeCreate<TProperties>>,
     pub auto_create_start_nodes: Option<bool>,
@@ -31,9 +32,9 @@ pub enum NodeOrEdgeCreate<TProperties> {
     Edge(EdgeWrite<TProperties>),
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct NodeWrite<TProperties> {
     pub space: String,
     pub external_id: String,
@@ -41,9 +42,9 @@ pub struct NodeWrite<TProperties> {
     pub existing_version: Option<i64>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct EdgeWrite<TProperties> {
     pub space: String,
     pub r#type: DirectRelationReference,
@@ -72,14 +73,7 @@ pub struct SourceReferenceId {
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum SourceReference {
     View(SourceReferenceId),
-    Container(SourceReferenceId),
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "lowercase")]
-pub enum SourceReferenceType {
-    View,
-    Container,
+    Container(InstanceId),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -89,9 +83,9 @@ pub enum SlimNodeOrEdge {
     Edge(SlimEdgeDefinition),
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct SlimNodeDefinition {
     pub space: String,
     pub version: i64,
@@ -100,9 +94,9 @@ pub struct SlimNodeDefinition {
     pub created_time: Option<i64>,
     pub last_updated_time: Option<i64>,
 }
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct SlimEdgeDefinition {
     pub space: String,
     pub version: i64,
@@ -164,7 +158,7 @@ pub enum NodeOrEdgeSpecification {
     Edge(InstanceId),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct InstanceId {
     pub space: String,
@@ -173,7 +167,6 @@ pub struct InstanceId {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-#[serde_with::skip_serializing_none]
 pub struct InstancesFilter {
     // todo
 }

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -1,7 +1,7 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Serialize, Deserialize, Derivative, Clone)]
+#[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde_with::skip_serializing_none]
 pub struct NodeAndEdgeCreateCollection<TProperties> {
@@ -24,39 +24,27 @@ impl<TProperties> Default for NodeAndEdgeCreateCollection<TProperties> {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase", untagged)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase", tag = "instanceType")]
 pub enum NodeOrEdgeCreate<TProperties> {
     Node(NodeWrite<TProperties>),
     Edge(EdgeWrite<TProperties>),
 }
 
-#[derive(Serialize, Deserialize, Default, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum InstanceType {
-    #[default]
-    Node,
-    Edge,
-}
-
-#[derive(Serialize, Deserialize, Default, Derivative, Clone)]
+#[derive(Serialize, Deserialize, Default, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde_with::skip_serializing_none]
 pub struct NodeWrite<TProperties> {
-    #[derivative(Default(value = "InstanceType::Node"))]
-    pub instance_type: InstanceType,
     pub space: String,
     pub external_id: String,
     pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
     pub existing_version: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Default, Derivative, Clone)]
+#[derive(Serialize, Deserialize, Default, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 #[serde_with::skip_serializing_none]
 pub struct EdgeWrite<TProperties> {
-    #[derivative(Default(value = "InstanceType::Edge"))]
-    pub instance_type: InstanceType,
     pub space: String,
     pub r#type: DirectRelationReference,
     pub external_id: String,
@@ -66,22 +54,28 @@ pub struct EdgeWrite<TProperties> {
     pub existing_version: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct EdgeOrNodeData<TProperties> {
     pub source: SourceReference,
     pub properties: TProperties,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct SourceReference {
-    pub r#type: SourceReferenceType,
+pub struct SourceReferenceId {
     pub space: String,
     pub external_id: String,
     pub version: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum SourceReference {
+    View(SourceReferenceId),
+    Container(SourceReferenceId),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum SourceReferenceType {
     View,
@@ -89,10 +83,27 @@ pub enum SourceReferenceType {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase", tag = "instanceType")]
+pub enum SlimNodeOrEdge {
+    Node(SlimNodeDefinition),
+    Edge(SlimEdgeDefinition),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde_with::skip_serializing_none]
-pub struct SlimNodeOrEdge {
-    pub instance_type: InstanceType,
+pub struct SlimNodeDefinition {
+    pub space: String,
+    pub version: i64,
+    pub was_modified: bool,
+    pub external_id: String,
+    pub created_time: Option<i64>,
+    pub last_updated_time: Option<i64>,
+}
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde_with::skip_serializing_none]
+pub struct SlimEdgeDefinition {
     pub space: String,
     pub version: i64,
     pub was_modified: bool,
@@ -101,25 +112,30 @@ pub struct SlimNodeOrEdge {
     pub last_updated_time: Option<i64>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "instanceType")]
+pub enum NodeOrEdge<TProperties> {
+    Node(NodeDefinition<TProperties>),
+    Edge(EdgeDefinition<TProperties>),
+}
+
 #[derive(Serialize, Deserialize, Derivative)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeDefinition<TProperties> {
-    #[derivative(Default(value = "InstanceType::Node"))]
-    pub instance_type: InstanceType,
     pub space: String,
     pub version: String,
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub properties: Option<Vec<TProperties>>,
     pub created_time: i64,
     pub last_updated_time: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<Vec<TProperties>>,
 }
 
 #[derive(Serialize, Deserialize, Derivative)]
 #[serde(rename_all = "camelCase")]
 pub struct EdgeDefinition<TProperties> {
-    #[derivative(Default(value = "InstanceType::Edge"))]
-    pub instance_type: InstanceType,
     pub space: String,
     pub r#type: DirectRelationReference,
     pub version: String,
@@ -129,39 +145,33 @@ pub struct EdgeDefinition<TProperties> {
     pub start_node: DirectRelationReference,
     pub end_node: DirectRelationReference,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_time: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<Vec<TProperties>>,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum NodeOrEdge<TProperties> {
-    Node(NodeDefinition<TProperties>),
-    Edge(EdgeDefinition<TProperties>),
-}
-
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DirectRelationReference {
     pub space: String,
     pub external_id: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct InstanceInfo {
-    pub instance_type: InstanceType,
-    pub external_id: String,
-    pub space: String,
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "instanceType")]
+pub enum NodeOrEdgeSpecification {
+    Node(InstanceId),
+    Edge(InstanceId),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InstanceId {
-    pub external_id: String,
     pub space: String,
+    pub external_id: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[serde_with::skip_serializing_none]
 pub struct InstancesFilter {

--- a/cognite/src/dto/data_modeling/mod.rs
+++ b/cognite/src/dto/data_modeling/mod.rs
@@ -1,0 +1,1 @@
+pub mod instances;

--- a/cognite/src/dto/mod.rs
+++ b/cognite/src/dto/mod.rs
@@ -7,6 +7,7 @@ pub mod patch_item;
 pub mod auth;
 pub mod core;
 pub mod data_ingestion;
+pub mod data_modeling;
 pub mod data_organization;
 pub mod iam;
 pub mod identity;

--- a/cognite/src/lib.rs
+++ b/cognite/src/lib.rs
@@ -62,6 +62,11 @@ pub mod sequences {
     pub use super::dto::core::sequences::*;
 }
 
+pub mod models {
+    pub use super::api::data_modeling::*;
+    pub use super::dto::data_modeling::instances::*;
+}
+
 pub mod iam {
     pub use super::api::iam::{
         api_keys::*, groups::*, security_categories::*, service_accounts::*, sessions::*,

--- a/cognite/tests/asset_tests.rs
+++ b/cognite/tests/asset_tests.rs
@@ -1,7 +1,8 @@
+#[cfg(test)]
 use cognite::assets::*;
 use cognite::*;
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 #[tokio::test]
 async fn create_and_delete_asset() {

--- a/cognite/tests/asset_tests.rs
+++ b/cognite/tests/asset_tests.rs
@@ -1,7 +1,7 @@
 use cognite::assets::*;
 use cognite::*;
 mod common;
-use common::*;
+pub(crate) use common::*;
 
 #[tokio::test]
 async fn create_and_delete_asset() {

--- a/cognite/tests/common/mod.rs
+++ b/cognite/tests/common/mod.rs
@@ -39,3 +39,7 @@ pub static PREFIX: Lazy<String> = Lazy::new(|| {
             .collect::<String>()
     )
 });
+
+pub fn get_path(base_url: &str, project: &str, endpoint: &str) -> String {
+    format!("{}/api/v1/projects/{}/{}", base_url, project, endpoint)
+}

--- a/cognite/tests/common/mod.rs
+++ b/cognite/tests/common/mod.rs
@@ -1,11 +1,10 @@
 #[cfg(test)]
+use cognite::ClientConfig;
 use cognite::CogniteClient;
 use once_cell::sync::Lazy;
 use rand::{distributions::Alphanumeric, Rng};
 
 pub fn get_client() -> CogniteClient {
-    use cognite::ClientConfig;
-
     CogniteClient::new_oidc(
         "rust_sdk_test",
         Some(ClientConfig {

--- a/cognite/tests/common/mod.rs
+++ b/cognite/tests/common/mod.rs
@@ -1,8 +1,8 @@
+#[cfg(test)]
 use cognite::CogniteClient;
 use once_cell::sync::Lazy;
 use rand::{distributions::Alphanumeric, Rng};
 
-#[cfg(test)]
 pub fn get_client() -> CogniteClient {
     use cognite::ClientConfig;
 
@@ -16,7 +16,20 @@ pub fn get_client() -> CogniteClient {
     .unwrap()
 }
 
-#[cfg(test)]
+pub fn get_client_for_mocking(api_base_url: &str, project_name: &str) -> CogniteClient {
+    CogniteClient::new_custom_auth(
+        api_base_url,
+        project_name,
+        cognite::AuthHeaderManager::AuthTicket("my_ticket".to_string()),
+        "rust_sdk_test",
+        Some(ClientConfig {
+            max_retries: 5,
+            ..Default::default()
+        }),
+    )
+    .unwrap()
+}
+
 pub static PREFIX: Lazy<String> = Lazy::new(|| {
     format!(
         "rust-sdk-test-{}",

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -2,7 +2,7 @@ use cognite::time_series::*;
 use cognite::*;
 
 mod common;
-use common::*;
+pub(crate) use common::*;
 
 async fn create_test_ts(client: &CogniteClient, is_string: bool, idx: i32) -> TimeSerie {
     let ts = AddTimeSerie {

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -1,8 +1,9 @@
+#[cfg(test)]
 use cognite::time_series::*;
 use cognite::*;
 
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 async fn create_test_ts(client: &CogniteClient, is_string: bool, idx: i32) -> TimeSerie {
     let ts = AddTimeSerie {

--- a/cognite/tests/event_tests.rs
+++ b/cognite/tests/event_tests.rs
@@ -1,5 +1,6 @@
+#[cfg(test)]
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 use cognite::events::*;
 use cognite::*;

--- a/cognite/tests/event_tests.rs
+++ b/cognite/tests/event_tests.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::*;
+pub(crate) use common::*;
 
 use cognite::events::*;
 use cognite::*;

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use bytes::Bytes;
 use cognite::files::*;
 use cognite::prelude::*;
@@ -6,7 +7,7 @@ use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 async fn ensure_test_file(client: &CogniteClient) {
     let id = "rust-sdk-test-file".to_string();

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -1,11 +1,12 @@
 use bytes::Bytes;
 use cognite::files::*;
 use cognite::prelude::*;
-mod common;
-use common::*;
 use futures::TryStreamExt;
 use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};
+
+mod common;
+pub(crate) use common::*;
 
 async fn ensure_test_file(client: &CogniteClient) {
     let id = "rust-sdk-test-file".to_string();

--- a/cognite/tests/fixtures/mod.rs
+++ b/cognite/tests/fixtures/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use std::collections::HashMap;
 
 use cognite::models::{
@@ -12,7 +13,7 @@ fn get_mock_properties() -> HashMap<String, String> {
     properties
 }
 
-pub(crate) fn get_mock_instances(
+pub fn get_mock_instances(
     space: &str,
     node_external_id: &[&str],
     edge_external_id: &[&str],
@@ -69,7 +70,7 @@ pub(crate) fn get_mock_instances(
     mock_instances
 }
 
-pub(crate) fn get_instances_create_request_string(
+pub fn get_instances_create_request_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -89,11 +90,13 @@ pub(crate) fn get_instances_create_request_string(
 
     items.pop(); // remove last comma
 
-    let req = format!(r#"{{"items": [{items}] }}"#);
+    let req = format!(
+        r#"{{"items":[{items}], "autoCreateStartNodes":false, "autoCreateEndNodes":false,"skipOnVersionConflict":false, "replace":false}}"#
+    );
     req
 }
 
-pub(crate) fn get_instances_create_response_string(
+pub fn get_instances_create_response_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -118,7 +121,7 @@ pub(crate) fn get_instances_create_response_string(
     res
 }
 
-pub(crate) fn get_mock_instances_delete(
+pub fn get_mock_instances_delete(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -139,7 +142,7 @@ pub(crate) fn get_mock_instances_delete(
     instances
 }
 
-pub(crate) fn get_instances_delete_request_string(
+pub fn get_instances_delete_request_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -160,7 +163,7 @@ pub(crate) fn get_instances_delete_request_string(
     format!(r#"{{"items": [ {items} ] }}"#)
 }
 
-pub(crate) fn get_instances_delete_response_string(
+pub fn get_instances_delete_response_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],

--- a/cognite/tests/fixtures/mod.rs
+++ b/cognite/tests/fixtures/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use cognite::models::{
-    DirectRelationReference, EdgeOrNodeData, EdgeWrite, InstanceInfo, InstanceType,
-    NodeOrEdgeCreate, NodeWrite, SourceReference, SourceReferenceType,
+    DirectRelationReference, EdgeOrNodeData, EdgeWrite, InstanceId, NodeOrEdgeCreate,
+    NodeOrEdgeSpecification, NodeWrite, SourceReference, SourceReferenceId,
 };
 
 fn get_mock_properties() -> HashMap<String, String> {
@@ -27,16 +27,14 @@ pub(crate) fn get_mock_instances(
             .iter()
             .map(|id| {
                 NodeOrEdgeCreate::Node(NodeWrite {
-                    instance_type: InstanceType::Node,
                     space: space.to_owned(),
                     external_id: id.to_string(),
                     sources: Some(vec![EdgeOrNodeData {
-                        source: SourceReference {
-                            r#type: SourceReferenceType::View,
+                        source: SourceReference::View(SourceReferenceId {
                             space: space.to_owned(),
                             external_id: "some_view".to_string(),
                             version: "1".to_string(),
-                        },
+                        }),
                         properties: properties.clone(),
                     }]),
                     ..Default::default()
@@ -49,7 +47,6 @@ pub(crate) fn get_mock_instances(
             .iter()
             .map(|id| {
                 NodeOrEdgeCreate::Edge(EdgeWrite {
-                    instance_type: InstanceType::Edge,
                     r#type: DirectRelationReference {
                         space: space.to_owned(),
                         external_id: id.to_string(),
@@ -125,21 +122,19 @@ pub(crate) fn get_mock_instances_delete(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
-) -> Vec<InstanceInfo> {
+) -> Vec<NodeOrEdgeSpecification> {
     let mut instances = Vec::new();
     node_external_ids.iter().for_each(|id| {
-        instances.push(InstanceInfo {
-            instance_type: InstanceType::Node,
+        instances.push(NodeOrEdgeSpecification::Node(InstanceId {
             space: space.to_owned(),
             external_id: id.to_string(),
-        });
+        }));
     });
     edge_external_ids.iter().for_each(|id| {
-        instances.push(InstanceInfo {
-            instance_type: InstanceType::Edge,
+        instances.push(NodeOrEdgeSpecification::Edge(InstanceId {
             space: space.to_owned(),
             external_id: id.to_string(),
-        });
+        }));
     });
     instances
 }

--- a/cognite/tests/fixtures/mod.rs
+++ b/cognite/tests/fixtures/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cognite::models::{
-    DirectRelationReference, EdgeOrNodeData, EdgeType, EdgeWrite, InstanceInfo, InstanceType,
+    DirectRelationReference, EdgeOrNodeData, EdgeWrite, InstanceInfo, InstanceType,
     NodeOrEdgeCreate, NodeWrite, SourceReference, SourceReferenceType,
 };
 
@@ -50,7 +50,7 @@ pub(crate) fn get_mock_instances(
             .map(|id| {
                 NodeOrEdgeCreate::Edge(EdgeWrite {
                     instance_type: InstanceType::Edge,
-                    r#type: EdgeType {
+                    r#type: DirectRelationReference {
                         space: space.to_owned(),
                         external_id: id.to_string(),
                     },

--- a/cognite/tests/fixtures/mod.rs
+++ b/cognite/tests/fixtures/mod.rs
@@ -12,7 +12,7 @@ fn get_mock_properties() -> HashMap<String, String> {
     properties
 }
 
-pub fn get_mock_instances(
+pub(crate) fn get_mock_instances(
     space: &str,
     node_external_id: &[&str],
     edge_external_id: &[&str],
@@ -72,7 +72,7 @@ pub fn get_mock_instances(
     mock_instances
 }
 
-pub fn get_instances_create_request_string(
+pub(crate) fn get_instances_create_request_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -96,7 +96,7 @@ pub fn get_instances_create_request_string(
     req
 }
 
-pub fn get_instances_create_response_string(
+pub(crate) fn get_instances_create_response_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -121,7 +121,7 @@ pub fn get_instances_create_response_string(
     res
 }
 
-pub fn get_mock_instances_delete(
+pub(crate) fn get_mock_instances_delete(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -144,7 +144,7 @@ pub fn get_mock_instances_delete(
     instances
 }
 
-pub fn get_instances_delete_request_string(
+pub(crate) fn get_instances_delete_request_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],
@@ -165,7 +165,7 @@ pub fn get_instances_delete_request_string(
     format!(r#"{{"items": [ {items} ] }}"#)
 }
 
-pub fn get_instances_delete_response_string(
+pub(crate) fn get_instances_delete_response_string(
     space: &str,
     node_external_ids: &[&str],
     edge_external_ids: &[&str],

--- a/cognite/tests/fixtures/mod.rs
+++ b/cognite/tests/fixtures/mod.rs
@@ -1,0 +1,187 @@
+use std::collections::HashMap;
+
+use cognite::models::{
+    DirectRelationReference, EdgeOrNodeData, EdgeType, EdgeWrite, InstanceInfo, InstanceType,
+    NodeOrEdgeCreate, NodeWrite, SourceReference, SourceReferenceType,
+};
+
+fn get_mock_properties() -> HashMap<String, String> {
+    let mut properties = std::collections::HashMap::new();
+    properties.insert("key1".to_string(), "value1".to_string());
+    properties.insert("key2".to_string(), "value2".to_string());
+    properties
+}
+
+pub fn get_mock_instances(
+    space: &str,
+    node_external_id: &[&str],
+    edge_external_id: &[&str],
+) -> Vec<NodeOrEdgeCreate<HashMap<std::string::String, std::string::String>>> {
+    let properties = get_mock_properties();
+
+    let mut mock_instances: Vec<NodeOrEdgeCreate<HashMap<String, String>>> = Vec::new();
+
+    // add nodes
+    mock_instances.extend(
+        node_external_id
+            .iter()
+            .map(|id| {
+                NodeOrEdgeCreate::Node(NodeWrite {
+                    instance_type: InstanceType::Node,
+                    space: space.to_owned(),
+                    external_id: id.to_string(),
+                    sources: Some(vec![EdgeOrNodeData {
+                        source: SourceReference {
+                            r#type: SourceReferenceType::View,
+                            space: space.to_owned(),
+                            external_id: "some_view".to_string(),
+                            version: "1".to_string(),
+                        },
+                        properties: properties.clone(),
+                    }]),
+                    ..Default::default()
+                })
+            })
+            .collect::<Vec<_>>(),
+    );
+    mock_instances.extend(
+        edge_external_id
+            .iter()
+            .map(|id| {
+                NodeOrEdgeCreate::Edge(EdgeWrite {
+                    instance_type: InstanceType::Edge,
+                    r#type: EdgeType {
+                        space: space.to_owned(),
+                        external_id: id.to_string(),
+                    },
+                    space: space.to_owned(),
+                    external_id: id.to_string(),
+                    start_node: DirectRelationReference {
+                        space: space.to_owned(),
+                        external_id: "start_node".to_string(),
+                    },
+                    end_node: DirectRelationReference {
+                        space: space.to_owned(),
+                        external_id: "end_node".to_string(),
+                    },
+                    ..Default::default()
+                })
+            })
+            .collect::<Vec<_>>(),
+    );
+    mock_instances
+}
+
+pub fn get_instances_create_request_string(
+    space: &str,
+    node_external_ids: &[&str],
+    edge_external_ids: &[&str],
+) -> String {
+    let properties = serde_json::to_string(&get_mock_properties()).unwrap();
+    let mut items = "".to_string();
+    node_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "node", "space": "{space}", "externalId": "{id}", "sources": [{{"source": {{ "type": "view", "space": "{space}", "externalId": "some_view", "version": "1" }}, "properties": {properties}  }}] }},"#,
+        ));
+    });
+    edge_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "edge", "space": "{space}", "externalId": "{id}", "type": {{ "space": "{space}", "externalId": "{id}" }}, "startNode": {{ "space": "{space}", "externalId": "start_node" }}, "endNode": {{ "space": "{space}", "externalId": "end_node" }} }},"#,
+        ));
+    });
+
+    items.pop(); // remove last comma
+
+    let req = format!(r#"{{"items": [{items}] }}"#);
+    req
+}
+
+pub fn get_instances_create_response_string(
+    space: &str,
+    node_external_ids: &[&str],
+    edge_external_ids: &[&str],
+) -> String {
+    let base_response = format!(
+        r#""version": 1, "space": "{space}", "wasModified": true,  "createdTime": 0, "lastUpdatedTime": 0"#
+    );
+    let mut items = "".to_string();
+    node_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "node", "externalId": "{id}", {base_response} }},"#,
+        ));
+    });
+    edge_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "edge", "externalId": "{id}", {base_response} }},"#,
+        ));
+    });
+    items.pop(); // remove last comma
+
+    let res = format!(r#"{{"items": [ {items} ] }}"#);
+    res
+}
+
+pub fn get_mock_instances_delete(
+    space: &str,
+    node_external_ids: &[&str],
+    edge_external_ids: &[&str],
+) -> Vec<InstanceInfo> {
+    let mut instances = Vec::new();
+    node_external_ids.iter().for_each(|id| {
+        instances.push(InstanceInfo {
+            instance_type: InstanceType::Node,
+            space: space.to_owned(),
+            external_id: id.to_string(),
+        });
+    });
+    edge_external_ids.iter().for_each(|id| {
+        instances.push(InstanceInfo {
+            instance_type: InstanceType::Edge,
+            space: space.to_owned(),
+            external_id: id.to_string(),
+        });
+    });
+    instances
+}
+
+pub fn get_instances_delete_request_string(
+    space: &str,
+    node_external_ids: &[&str],
+    edge_external_ids: &[&str],
+) -> String {
+    let mut items = "".to_string();
+    node_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "node", "externalId": "{id}", "space": "{space}" }},"#,
+        ));
+    });
+    edge_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "edge", "externalId": "{id}", "space": "{space}" }},"#,
+        ));
+    });
+    items.pop(); // remove last comma
+
+    format!(r#"{{"items": [ {items} ] }}"#)
+}
+
+pub fn get_instances_delete_response_string(
+    space: &str,
+    node_external_ids: &[&str],
+    edge_external_ids: &[&str],
+) -> String {
+    let mut items = "".to_string();
+    node_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "node", "externalId": "{id}", "space": "{space}" }},"#,
+        ));
+    });
+    edge_external_ids.iter().for_each(|id| {
+        items.push_str(&format!(
+            r#"{{"instanceType": "edge", "externalId": "{id}", "space": "{space}" }},"#,
+        ));
+    });
+    items.pop(); // remove last comma
+
+    format!(r#"{{"items": [ {items} ] }}"#)
+}

--- a/cognite/tests/instances_tests.rs
+++ b/cognite/tests/instances_tests.rs
@@ -1,0 +1,81 @@
+#[cfg(test)]
+use cognite::models::*;
+use cognite::*;
+
+use wiremock::matchers::{body_json_string, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::*;
+
+mod fixtures;
+use fixtures::*;
+
+#[tokio::test]
+async fn create_and_delete_instances() {
+    let project = "my_project";
+    let space = "my_space";
+    let node_external_ids = vec!["node1", "node2"];
+    let edge_external_ids = vec!["edge1"];
+
+    let mock_server = MockServer::start().await;
+
+    // mock create instance
+    Mock::given(method("POST"))
+        .and(body_json_string(get_instances_create_request_string(
+            space,
+            &node_external_ids,
+            &edge_external_ids,
+        )))
+        .and(path(get_path("", project, "models/instances")))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            get_instances_create_response_string(space, &node_external_ids, &edge_external_ids),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    // mock delete instance
+    Mock::given(method("POST"))
+        .and(path(get_path("", project, "models/instances/delete")))
+        .and(body_json_string(get_instances_delete_request_string(
+            space,
+            &node_external_ids,
+            &edge_external_ids,
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            get_instances_delete_response_string(space, &node_external_ids, &edge_external_ids),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    // create instances
+    let client = get_client_for_mocking(&mock_server.uri(), project);
+
+    let mock_instances = get_mock_instances(space, &node_external_ids, &edge_external_ids);
+    let upsert_collection = NodeAndEdgeCreateCollection {
+        items: mock_instances.clone(),
+        ..Default::default()
+    };
+
+    let result = client
+        .models
+        .instances
+        .upsert(&upsert_collection)
+        .await
+        .unwrap();
+
+    assert_eq!(result.len(), mock_instances.len());
+
+    // and delete the instances
+    let instances_delete = get_mock_instances_delete(space, &node_external_ids, &edge_external_ids);
+
+    let results = client
+        .models
+        .instances
+        .delete(&instances_delete)
+        .await
+        .unwrap()
+        .items;
+
+    assert_eq!(results.len(), instances_delete.len());
+}

--- a/cognite/tests/instances_tests.rs
+++ b/cognite/tests/instances_tests.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 #[cfg(test)]
 use cognite::models::*;
 use cognite::*;
@@ -8,10 +6,10 @@ use wiremock::matchers::{body_json_string, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 mod fixtures;
-pub(crate) use fixtures::*;
+pub use fixtures::*;
 
 #[tokio::test]
 async fn create_and_delete_instances() {
@@ -66,7 +64,27 @@ async fn create_and_delete_instances() {
         .await
         .unwrap();
 
-    assert_eq!(result.len(), mock_instances.len());
+    assert_eq!(
+        result
+            .iter()
+            .filter(|&x| match x {
+                SlimNodeOrEdge::Node(_) => true,
+                _ => false,
+            })
+            .count(),
+        node_external_ids.len()
+    );
+
+    assert_eq!(
+        result
+            .iter()
+            .filter(|&x| match x {
+                SlimNodeOrEdge::Edge(_) => true,
+                _ => false,
+            })
+            .count(),
+        edge_external_ids.len()
+    );
 
     // and delete the instances
     let instances_delete = get_mock_instances_delete(space, &node_external_ids, &edge_external_ids);
@@ -79,5 +97,25 @@ async fn create_and_delete_instances() {
         .unwrap()
         .items;
 
-    assert_eq!(results.len(), instances_delete.len());
+    assert_eq!(
+        results
+            .iter()
+            .filter(|&x| match x {
+                NodeOrEdgeSpecification::Node(_) => true,
+                _ => false,
+            })
+            .count(),
+        node_external_ids.len()
+    );
+
+    assert_eq!(
+        results
+            .iter()
+            .filter(|&x| match x {
+                NodeOrEdgeSpecification::Edge(_) => true,
+                _ => false,
+            })
+            .count(),
+        edge_external_ids.len()
+    );
 }

--- a/cognite/tests/instances_tests.rs
+++ b/cognite/tests/instances_tests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[cfg(test)]
 use cognite::models::*;
 use cognite::*;

--- a/cognite/tests/instances_tests.rs
+++ b/cognite/tests/instances_tests.rs
@@ -6,10 +6,10 @@ use wiremock::matchers::{body_json_string, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
-use common::*;
+pub(crate) use common::*;
 
 mod fixtures;
-use fixtures::*;
+pub(crate) use fixtures::*;
 
 #[tokio::test]
 async fn create_and_delete_instances() {

--- a/cognite/tests/time_serie_tests.rs
+++ b/cognite/tests/time_serie_tests.rs
@@ -1,5 +1,6 @@
+#[cfg(test)]
 mod common;
-pub(crate) use common::*;
+pub use common::*;
 
 use cognite::time_series::*;
 use cognite::*;

--- a/cognite/tests/time_serie_tests.rs
+++ b/cognite/tests/time_serie_tests.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::*;
+pub(crate) use common::*;
 
 use cognite::time_series::*;
 use cognite::*;


### PR DESCRIPTION
Minimal implementation of the DMSv3 `models/instances` endpoint.

Changes: 
- Added create, list, delete, retrieve (minimal) for instances.
- Added DTOs for instances, following the [openapi spec](https://cog.link/dmsv3) as much as possible (naming, etc)
- Tests for the endpoint use a mock server: in order to properly test w.r.t. CDF we also need the `spaces` and `views` endpoints (to-do)