### PR TITLE
Misc cleanup and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,13 @@ $ export COGNITE_PROJECT=<your project name>
 - Assets
 - Events
 - Files
-  - Without upload/download
 - TimeSeries
   - With protobuf support
 - Sequences
 ### IAM
-- ApiKeys
 - Groups
 - SecurityCategories
-- ServiceAccounts
+- Sessions
 ### Data Ingestion
 - Extraction pipelines
 - Raw
@@ -45,7 +43,9 @@ $ export COGNITE_PROJECT=<your project name>
 - Labels
 - Relationships
 ### Data Modeling
-- Instances (minimal implementation)
+- Instances 
+- Spaces
+- Views
 
 ## Example
 
@@ -65,11 +65,12 @@ use cognite::{Asset, AssetFilter, AssetSearch, CogniteClient};
 
 #[tokio::main]
 fn main() {
-    let cognite_client = CogniteClient::new("TestApp").unwrap();
+    // Create a client from environment variables
+    let cognite_client = CogniteClient::new("TestApp", None).unwrap();
 
     // List all assets
     let mut filter: AssetFilter = AssetFilter::new();
-    filter.name.replace("Aker".to_string());
+    filter.name = Some("Aker".to_string());
     let assets = cognite_client
         .assets
         .filter(FilterAssetsRequest {

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -71,10 +71,10 @@ where
 
     async fn create_from<T: 'a, 'a>(&self, creates: &'a [T]) -> Result<Vec<TResponse>>
     where
-        T: std::marker::Sync,
-        TCreate: From<&'a T>,
+        T: std::marker::Sync + Clone,
+        TCreate: From<T>,
     {
-        let to_add: Vec<TCreate> = creates.iter().map(TCreate::from).collect();
+        let to_add: Vec<TCreate> = creates.iter().map(|i| TCreate::from(i.clone())).collect();
         self.create(&to_add).await
     }
 
@@ -113,10 +113,10 @@ where
         creates: &'a [T],
     ) -> Result<Vec<TResponse>>
     where
-        T: std::marker::Sync,
-        TCreate: From<&'a T> + EqIdentity,
+        T: std::marker::Sync + Clone,
+        TCreate: From<T> + EqIdentity,
     {
-        let to_add: Vec<TCreate> = creates.iter().map(TCreate::from).collect();
+        let to_add: Vec<TCreate> = creates.iter().map(|i| TCreate::from(i.clone())).collect();
         self.create_ignore_duplicates(&to_add).await
     }
 }
@@ -128,8 +128,8 @@ pub trait FromDuplicateCreate<'a, TCreate> {
 #[async_trait]
 pub trait Upsert<TCreate, TUpdate, TResponse, 'a>
 where
-    TCreate: Serialize + Sync + Send + EqIdentity + 'a,
-    TUpdate: Serialize + Sync + Send + From<&'a TCreate> + Default,
+    TCreate: Serialize + Sync + Send + EqIdentity + 'a + Clone,
+    TUpdate: Serialize + Sync + Send + From<TCreate> + Default,
     TResponse: Serialize + DeserializeOwned + Sync + Send,
     Self: WithApiClient + WithBasePath,
 {
@@ -148,7 +148,7 @@ where
                 if let Some(idt) = idt {
                     to_update.push(Patch::<TUpdate> {
                         id: idt.clone(),
-                        update: TUpdate::from(it),
+                        update: TUpdate::from(it.clone()),
                     });
                 } else {
                     to_create.push(it);
@@ -184,8 +184,8 @@ where
 impl<'a, T, TCreate, TUpdate, TResponse> Upsert<'a, TCreate, TUpdate, TResponse> for T
 where
     T: Create<TCreate, TResponse> + Update<Patch<TUpdate>, TResponse>,
-    TCreate: Serialize + Sync + Send + EqIdentity + 'a,
-    TUpdate: Serialize + Sync + Send + From<&'a TCreate> + Default,
+    TCreate: Serialize + Sync + Send + EqIdentity + 'a + Clone,
+    TUpdate: Serialize + Sync + Send + From<TCreate> + Default,
     TResponse: Serialize + DeserializeOwned + Sync + Send,
 {
 }
@@ -287,10 +287,10 @@ where
 
     async fn update_from<T: 'a, 'a>(&self, updates: &'a [T]) -> Result<Vec<TResponse>>
     where
-        T: std::marker::Sync,
-        TUpdate: From<&'a T>,
+        T: std::marker::Sync + Clone,
+        TUpdate: From<T>,
     {
-        let to_update: Vec<TUpdate> = updates.iter().map(TUpdate::from).collect();
+        let to_update: Vec<TUpdate> = updates.iter().map(|i| TUpdate::from(i.clone())).collect();
         self.update(&to_update).await
     }
 
@@ -331,11 +331,11 @@ where
         updates: &'a [T],
     ) -> Result<Vec<TResponse>>
     where
-        T: std::marker::Sync,
-        TUpdate: From<&'a T> + EqIdentity,
+        T: std::marker::Sync + Clone,
+        TUpdate: From<T> + EqIdentity,
         TResponse: Send,
     {
-        let to_update: Vec<TUpdate> = updates.iter().map(TUpdate::from).collect();
+        let to_update: Vec<TUpdate> = updates.iter().map(|i| TUpdate::from(i.clone())).collect();
         self.update_ignore_unknown_ids(&to_update).await
     }
 }

--- a/cognite/src/dto/core/asset/filter.rs
+++ b/cognite/src/dto/core/asset/filter.rs
@@ -2,36 +2,25 @@ use crate::{
     to_query, AsParams, Identity, LabelsFilter, Partition, Range, SetCursor, WithPartition,
 };
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_subtree_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<LabelsFilter>,
 }
 
@@ -41,14 +30,12 @@ impl AssetFilter {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetSearch {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 }
 
@@ -58,17 +45,14 @@ impl AssetSearch {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterAssetsRequest {
     pub filter: AssetFilter,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregated_properties: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<String>,
 }
 

--- a/cognite/src/dto/core/asset/mod.rs
+++ b/cognite/src/dto/core/asset/mod.rs
@@ -7,9 +7,11 @@ use crate::{CogniteExternalId, CogniteId, EqIdentity, UpdateList};
 use crate::{Patch, UpdateMap, UpdateSet, UpdateSetNull};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetAggregate {
     pub child_count: Option<i32>,
@@ -17,7 +19,8 @@ pub struct AssetAggregate {
     pub path: Option<Vec<CogniteId>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
     pub id: i64,
@@ -64,44 +67,37 @@ impl Asset {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddAsset {
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<CogniteExternalId>>,
 }
 
-impl From<&Asset> for AddAsset {
-    fn from(asset: &Asset) -> AddAsset {
+impl From<Asset> for AddAsset {
+    fn from(asset: Asset) -> AddAsset {
         AddAsset {
-            name: asset.name.clone(),
-            external_id: asset.external_id.clone(),
+            name: asset.name,
+            external_id: asset.external_id,
             parent_id: asset.parent_id,
-            description: asset.description.clone(),
-            metadata: asset.metadata.clone(),
-            source: asset.source.clone(),
+            description: asset.description,
+            metadata: asset.metadata,
+            source: asset.source,
             parent_external_id: if asset.parent_id.is_none() {
-                asset.parent_external_id.clone()
+                asset.parent_external_id
             } else {
                 None
             },
             data_set_id: asset.data_set_id,
-            labels: asset.labels.clone(),
+            labels: asset.labels,
         }
     }
 }
@@ -115,64 +111,57 @@ impl EqIdentity for AddAsset {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchAsset {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<UpdateSet<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_external_id: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<UpdateList<CogniteExternalId, CogniteExternalId>>,
 }
 
-impl From<&Asset> for Patch<PatchAsset> {
-    fn from(asset: &Asset) -> Patch<PatchAsset> {
+impl From<Asset> for Patch<PatchAsset> {
+    fn from(asset: Asset) -> Patch<PatchAsset> {
         Patch::<PatchAsset> {
             id: to_idt!(asset),
             update: PatchAsset {
-                name: Some(asset.name.clone().into()),
-                external_id: Some(asset.external_id.clone().into()),
-                description: Some(asset.description.clone().into()),
-                metadata: Some(asset.metadata.clone().into()),
-                source: Some(asset.source.clone().into()),
+                name: Some(asset.name.into()),
+                external_id: Some(asset.external_id.into()),
+                description: Some(asset.description.into()),
+                metadata: Some(asset.metadata.into()),
+                source: Some(asset.source.into()),
                 parent_id: asset.parent_id.map(|p| p.into()),
                 parent_external_id: None,
-                labels: Some(asset.labels.clone().into()),
+                labels: Some(asset.labels.into()),
                 data_set_id: Some(asset.data_set_id.into()),
             },
         }
     }
 }
 
-impl From<&AddAsset> for PatchAsset {
-    fn from(asset: &AddAsset) -> Self {
+impl From<AddAsset> for PatchAsset {
+    fn from(asset: AddAsset) -> Self {
         PatchAsset {
-            name: Some(asset.name.clone().into()),
-            external_id: Some(asset.external_id.clone().into()),
-            description: Some(asset.description.clone().into()),
-            metadata: Some(asset.metadata.clone().into()),
-            source: Some(asset.source.clone().into()),
+            name: Some(asset.name.into()),
+            external_id: Some(asset.external_id.into()),
+            description: Some(asset.description.into()),
+            metadata: Some(asset.metadata.into()),
+            source: Some(asset.source.into()),
             parent_id: asset.parent_id.map(|p| p.into()),
             parent_external_id: None,
-            labels: Some(asset.labels.clone().into()),
+            labels: Some(asset.labels.into()),
             data_set_id: Some(asset.data_set_id.into()),
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveAssetsRequest {

--- a/cognite/src/dto/core/datapoint/filter.rs
+++ b/cognite/src/dto/core/datapoint/filter.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::Identity;
 
@@ -23,42 +24,31 @@ impl From<&str> for Aggregate {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DatapointsFilter {
     pub items: Vec<DatapointsQuery>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregates: Option<Vec<Aggregate>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub granularity: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub include_outside_points: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_unknown_ids: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DatapointsQuery {
     #[serde(flatten)]
     pub id: Identity,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregates: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub granularity: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub include_outside_points: Option<bool>,
 }
 

--- a/cognite/src/dto/core/event/filter.rs
+++ b/cognite/src/dto/core/event/filter.rs
@@ -3,6 +3,7 @@ use crate::{
     WithPartition,
 };
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
 #[derive(Debug, Default, Clone)]
@@ -111,36 +112,24 @@ impl WithPartition for EventQuery {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub active_at_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_subtree_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    #[serde(rename = "type")]
     pub r#type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub subtype: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
 }
 
@@ -150,6 +139,7 @@ impl EventFilter {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct EventFilterQuery {
     pub filter: EventFilter,
@@ -211,10 +201,10 @@ impl AggregatedEventsListFilter {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSearch {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 

--- a/cognite/src/dto/core/event/mod.rs
+++ b/cognite/src/dto/core/event/mod.rs
@@ -4,8 +4,10 @@ pub use self::filter::*;
 
 use crate::{EqIdentity, Identity, IntegerOrString, Patch, UpdateList, UpdateMap, UpdateSetNull};
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct EventListResponse {
@@ -45,7 +47,8 @@ impl EventCount {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
     pub id: i64,
@@ -63,7 +66,8 @@ pub struct Event {
     pub last_updated_time: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddEvent {
     pub external_id: Option<String>,
@@ -78,19 +82,19 @@ pub struct AddEvent {
     pub source: Option<String>,
 }
 
-impl From<&Event> for AddEvent {
-    fn from(event: &Event) -> AddEvent {
+impl From<Event> for AddEvent {
+    fn from(event: Event) -> AddEvent {
         AddEvent {
-            external_id: event.external_id.clone(),
+            external_id: event.external_id,
             data_set_id: event.data_set_id,
             start_time: event.start_time,
             end_time: event.end_time,
-            r#type: event.r#type.clone(),
-            subtype: event.subtype.clone(),
-            description: event.description.clone(),
-            metadata: event.metadata.clone(),
-            asset_ids: event.asset_ids.clone(),
-            source: event.source.clone(),
+            r#type: event.r#type,
+            subtype: event.subtype,
+            description: event.description,
+            metadata: event.metadata,
+            asset_ids: event.asset_ids,
+            source: event.source,
         }
     }
 }
@@ -104,64 +108,55 @@ impl EqIdentity for AddEvent {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<UpdateList<i64, i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub subtype: Option<UpdateSetNull<String>>,
 }
 
-impl From<&Event> for Patch<PatchEvent> {
-    fn from(event: &Event) -> Patch<PatchEvent> {
+impl From<Event> for Patch<PatchEvent> {
+    fn from(event: Event) -> Patch<PatchEvent> {
         Patch::<PatchEvent> {
             id: to_idt!(event),
             update: PatchEvent {
-                external_id: Some(event.external_id.clone().into()),
+                external_id: Some(event.external_id.into()),
                 data_set_id: Some(event.data_set_id.into()),
                 start_time: Some(event.start_time.into()),
                 end_time: Some(event.end_time.into()),
-                description: Some(event.description.clone().into()),
-                metadata: Some(event.metadata.clone().into()),
-                asset_ids: Some(event.asset_ids.clone().into()),
-                source: Some(event.source.clone().into()),
-                r#type: Some(event.r#type.clone().into()),
-                subtype: Some(event.subtype.clone().into()),
+                description: Some(event.description.into()),
+                metadata: Some(event.metadata.into()),
+                asset_ids: Some(event.asset_ids.into()),
+                source: Some(event.source.into()),
+                r#type: Some(event.r#type.into()),
+                subtype: Some(event.subtype.into()),
             },
         }
     }
 }
 
-impl From<&AddEvent> for PatchEvent {
-    fn from(event: &AddEvent) -> Self {
+impl From<AddEvent> for PatchEvent {
+    fn from(event: AddEvent) -> Self {
         PatchEvent {
-            external_id: Some(event.external_id.clone().into()),
+            external_id: Some(event.external_id.into()),
             data_set_id: Some(event.data_set_id.into()),
             start_time: Some(event.start_time.into()),
             end_time: Some(event.end_time.into()),
-            description: Some(event.description.clone().into()),
-            metadata: Some(event.metadata.clone().into()),
-            asset_ids: Some(event.asset_ids.clone().into()),
-            source: Some(event.source.clone().into()),
-            r#type: Some(event.r#type.clone().into()),
-            subtype: Some(event.subtype.clone().into()),
+            description: Some(event.description.into()),
+            metadata: Some(event.metadata.into()),
+            asset_ids: Some(event.asset_ids.into()),
+            source: Some(event.source.into()),
+            r#type: Some(event.r#type.into()),
+            subtype: Some(event.subtype.into()),
         }
     }
 }

--- a/cognite/src/dto/core/files/file.rs
+++ b/cognite/src/dto/core/files/file.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
 use crate::{CogniteExternalId, EqIdentity, Identity, Patch, UpdateList, UpdateMap, UpdateSetNull};
@@ -10,7 +11,8 @@ pub struct FileListResponse {
     next_cursor: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FileMetadata {
     pub external_id: Option<String>,
@@ -33,49 +35,39 @@ pub struct FileMetadata {
     pub upload_url: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddFile {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub directory: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_created_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_modified_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub security_categories: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<CogniteExternalId>>,
 }
 
-impl From<&FileMetadata> for AddFile {
-    fn from(file: &FileMetadata) -> AddFile {
+impl From<FileMetadata> for AddFile {
+    fn from(file: FileMetadata) -> AddFile {
         AddFile {
-            external_id: file.external_id.clone(),
-            name: file.name.clone(),
-            directory: file.directory.clone(),
-            source: file.source.clone(),
-            mime_type: file.mime_type.clone(),
-            metadata: file.metadata.clone(),
-            asset_ids: file.asset_ids.clone(),
+            external_id: file.external_id,
+            name: file.name,
+            directory: file.directory,
+            source: file.source,
+            mime_type: file.mime_type,
+            metadata: file.metadata,
+            asset_ids: file.asset_ids,
             data_set_id: file.data_set_id,
             source_created_time: file.source_created_time,
             source_modified_time: file.source_modified_time,
-            security_categories: file.security_categories.clone(),
-            labels: file.labels.clone(),
+            security_categories: file.security_categories,
+            labels: file.labels,
         }
     }
 }
@@ -89,68 +81,58 @@ impl EqIdentity for AddFile {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchFile {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub directory: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<UpdateList<i64, i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_created_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_modified_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub security_categories: Option<UpdateList<i64, i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<UpdateList<CogniteExternalId, CogniteExternalId>>,
 }
 
-impl From<&FileMetadata> for Patch<PatchFile> {
-    fn from(file: &FileMetadata) -> Self {
+impl From<FileMetadata> for Patch<PatchFile> {
+    fn from(file: FileMetadata) -> Self {
         Self {
             id: to_idt!(file),
             update: PatchFile {
-                external_id: Some(file.external_id.clone().into()),
-                directory: Some(file.directory.clone().into()),
-                source: Some(file.source.clone().into()),
-                mime_type: Some(file.mime_type.clone().into()),
-                metadata: Some(file.metadata.clone().into()),
-                asset_ids: Some(file.asset_ids.clone().into()),
+                external_id: Some(file.external_id.into()),
+                directory: Some(file.directory.into()),
+                source: Some(file.source.into()),
+                mime_type: Some(file.mime_type.into()),
+                metadata: Some(file.metadata.into()),
+                asset_ids: Some(file.asset_ids.into()),
                 source_created_time: Some(file.source_created_time.into()),
                 source_modified_time: Some(file.source_modified_time.into()),
                 data_set_id: Some(file.data_set_id.into()),
-                security_categories: Some(file.security_categories.clone().into()),
-                labels: Some(file.labels.clone().into()),
+                security_categories: Some(file.security_categories.into()),
+                labels: Some(file.labels.into()),
             },
         }
     }
 }
 
-impl From<&AddFile> for PatchFile {
-    fn from(file: &AddFile) -> Self {
+impl From<AddFile> for PatchFile {
+    fn from(file: AddFile) -> Self {
         Self {
-            external_id: Some(file.external_id.clone().into()),
-            directory: Some(file.directory.clone().into()),
-            source: Some(file.source.clone().into()),
-            mime_type: Some(file.mime_type.clone().into()),
-            metadata: Some(file.metadata.clone().into()),
-            asset_ids: Some(file.asset_ids.clone().into()),
+            external_id: Some(file.external_id.into()),
+            directory: Some(file.directory.into()),
+            source: Some(file.source.into()),
+            mime_type: Some(file.mime_type.into()),
+            metadata: Some(file.metadata.into()),
+            asset_ids: Some(file.asset_ids.into()),
             source_created_time: Some(file.source_created_time.into()),
             source_modified_time: Some(file.source_modified_time.into()),
             data_set_id: Some(file.data_set_id.into()),
-            security_categories: Some(file.security_categories.clone().into()),
-            labels: Some(file.labels.clone().into()),
+            security_categories: Some(file.security_categories.into()),
+            labels: Some(file.labels.into()),
         }
     }
 }

--- a/cognite/src/dto/core/files/filter.rs
+++ b/cognite/src/dto/core/files/filter.rs
@@ -1,42 +1,27 @@
 use crate::{AsParams, Identity, LabelsFilter, Range};
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FileFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub directory_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<Vec<u64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_asset_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_subtree_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub uploaded_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_modified_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub uploaded: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<LabelsFilter>,
 }
 
@@ -46,10 +31,10 @@ impl FileFilter {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FileSearch {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 

--- a/cognite/src/dto/core/sequences.rs
+++ b/cognite/src/dto/core/sequences.rs
@@ -1,6 +1,7 @@
 use crate::{EqIdentity, Identity, Patch, Range, UpdateList, UpdateMap, UpdateSet, UpdateSetNull};
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
@@ -15,6 +16,7 @@ pub enum SequenceValueType {
     Long,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceColumn {
@@ -29,7 +31,8 @@ pub struct SequenceColumn {
     pub last_updated_time: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Sequence {
     pub id: i64,
@@ -44,33 +47,28 @@ pub struct Sequence {
     pub data_set_id: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddSequence {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
     pub columns: Vec<SequenceColumn>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
 }
 
-impl From<&Sequence> for AddSequence {
-    fn from(sequence: &Sequence) -> Self {
+impl From<Sequence> for AddSequence {
+    fn from(sequence: Sequence) -> Self {
         AddSequence {
-            external_id: sequence.external_id.clone(),
-            name: sequence.name.clone(),
-            description: sequence.description.clone(),
+            external_id: sequence.external_id,
+            name: sequence.name,
+            description: sequence.description,
             asset_id: sequence.asset_id,
-            metadata: sequence.metadata.clone(),
-            columns: sequence.columns.clone(),
+            metadata: sequence.metadata,
+            columns: sequence.columns,
             data_set_id: sequence.data_set_id,
         }
     }
@@ -85,14 +83,12 @@ impl EqIdentity for AddSequence {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSequenceColumns {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub modify: Option<Vec<Patch<PatchSequenceColumn>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub add: Option<Vec<SequenceColumn>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub remove: Option<Vec<String>>,
 }
 
@@ -106,48 +102,39 @@ impl From<UpdateList<SequenceColumn, String>> for UpdateSequenceColumns {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchSequenceColumn {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchSequence {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<UpdateSequenceColumns>,
 }
 
-impl From<&Sequence> for Patch<PatchSequence> {
-    fn from(sequence: &Sequence) -> Self {
+impl From<Sequence> for Patch<PatchSequence> {
+    fn from(sequence: Sequence) -> Self {
         Self {
             id: Identity::Id { id: sequence.id },
             update: PatchSequence {
-                name: Some(sequence.name.clone().into()),
-                description: Some(sequence.description.clone().into()),
+                name: Some(sequence.name.into()),
+                description: Some(sequence.description.into()),
                 asset_id: Some(sequence.asset_id.into()),
-                external_id: Some(sequence.external_id.clone().into()),
-                metadata: Some(sequence.metadata.clone().into()),
+                external_id: Some(sequence.external_id.into()),
+                metadata: Some(sequence.metadata.into()),
                 data_set_id: Some(sequence.data_set_id.into()),
                 columns: None,
             },
@@ -155,51 +142,41 @@ impl From<&Sequence> for Patch<PatchSequence> {
     }
 }
 
-impl From<&AddSequence> for PatchSequence {
-    fn from(sequence: &AddSequence) -> Self {
+impl From<AddSequence> for PatchSequence {
+    fn from(sequence: AddSequence) -> Self {
         PatchSequence {
-            name: Some(sequence.name.clone().into()),
-            description: Some(sequence.description.clone().into()),
+            name: Some(sequence.name.into()),
+            description: Some(sequence.description.into()),
             asset_id: Some(sequence.asset_id.into()),
-            external_id: Some(sequence.external_id.clone().into()),
-            metadata: Some(sequence.metadata.clone().into()),
+            external_id: Some(sequence.external_id.into()),
+            metadata: Some(sequence.metadata.into()),
             data_set_id: Some(sequence.data_set_id.into()),
             columns: None,
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_asset_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_subtree_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SequenceSearch {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 }
 
@@ -226,15 +203,16 @@ pub struct SequenceRow {
     pub values: Vec<SequenceRowValue>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BasicSequenceColumn {
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub value_type: SequenceValueType,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveSequenceRowsResponse {
@@ -254,29 +232,24 @@ pub struct InsertSequenceRows {
     pub id: Identity,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveSequenceRows {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<String>>,
     #[serde(flatten)]
     pub id: Identity,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RetrieveLatestSequenceRow {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub before: Option<i64>,
     #[serde(flatten)]
     pub id: Identity,

--- a/cognite/src/dto/core/time_serie/filter.rs
+++ b/cognite/src/dto/core/time_serie/filter.rs
@@ -1,36 +1,25 @@
 use crate::{to_query, Identity, Partition, SetCursor, WithPartition};
 use crate::{AsParams, Range};
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeSerieFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_string: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_step: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_ids: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub root_asset_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_subtree_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
 }
 
@@ -40,14 +29,12 @@ impl TimeSerieFilter {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeSerieSearch {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 }
 

--- a/cognite/src/dto/core/time_serie/mod.rs
+++ b/cognite/src/dto/core/time_serie/mod.rs
@@ -5,9 +5,10 @@ pub use self::filter::*;
 use crate::{EqIdentity, Identity, Patch, UpdateList, UpdateMap, UpdateSet, UpdateSetNull};
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeSerie {
     pub id: i64,
@@ -25,41 +26,34 @@ pub struct TimeSerie {
     pub data_set_id: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddTimeSerie {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub is_string: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id: Option<i64>,
     pub is_step: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub security_categories: Option<Vec<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
 }
 
-impl From<&TimeSerie> for AddTimeSerie {
-    fn from(time_serie: &TimeSerie) -> AddTimeSerie {
+impl From<TimeSerie> for AddTimeSerie {
+    fn from(time_serie: TimeSerie) -> AddTimeSerie {
         AddTimeSerie {
-            name: time_serie.name.clone(),
-            external_id: time_serie.external_id.clone(),
+            name: time_serie.name,
+            external_id: time_serie.external_id,
             is_string: time_serie.is_string,
-            metadata: time_serie.metadata.clone(),
-            unit: time_serie.unit.clone(),
+            metadata: time_serie.metadata,
+            unit: time_serie.unit,
             asset_id: time_serie.asset_id,
             is_step: time_serie.is_step,
-            description: time_serie.description.clone(),
-            security_categories: time_serie.security_categories.clone(),
+            description: time_serie.description,
+            security_categories: time_serie.security_categories,
             data_set_id: time_serie.data_set_id,
         }
     }
@@ -74,41 +68,33 @@ impl EqIdentity for AddTimeSerie {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchTimeSerie {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub security_categories: Option<UpdateList<i64, i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_step: Option<UpdateSet<bool>>,
 }
 
-impl From<&TimeSerie> for Patch<PatchTimeSerie> {
-    fn from(time_serie: &TimeSerie) -> Patch<PatchTimeSerie> {
+impl From<TimeSerie> for Patch<PatchTimeSerie> {
+    fn from(time_serie: TimeSerie) -> Patch<PatchTimeSerie> {
         Patch::<PatchTimeSerie> {
             id: to_idt!(time_serie),
             update: PatchTimeSerie {
-                name: Some(time_serie.name.clone().into()),
-                external_id: Some(time_serie.external_id.clone().into()),
-                metadata: Some(time_serie.metadata.clone().into()),
-                unit: Some(time_serie.unit.clone().into()),
+                name: Some(time_serie.name.into()),
+                external_id: Some(time_serie.external_id.into()),
+                metadata: Some(time_serie.metadata.into()),
+                unit: Some(time_serie.unit.into()),
                 asset_id: Some(time_serie.asset_id.into()),
-                description: Some(time_serie.description.clone().into()),
-                security_categories: Some(time_serie.security_categories.clone().into()),
+                description: Some(time_serie.description.into()),
+                security_categories: Some(time_serie.security_categories.into()),
                 data_set_id: Some(time_serie.data_set_id.into()),
                 is_step: Some(time_serie.is_step.into()),
             },
@@ -116,16 +102,16 @@ impl From<&TimeSerie> for Patch<PatchTimeSerie> {
     }
 }
 
-impl From<&AddTimeSerie> for PatchTimeSerie {
-    fn from(time_serie: &AddTimeSerie) -> Self {
+impl From<AddTimeSerie> for PatchTimeSerie {
+    fn from(time_serie: AddTimeSerie) -> Self {
         PatchTimeSerie {
-            name: Some(time_serie.name.clone().into()),
-            external_id: Some(time_serie.external_id.clone().into()),
-            metadata: Some(time_serie.metadata.clone().into()),
-            unit: Some(time_serie.unit.clone().into()),
+            name: Some(time_serie.name.into()),
+            external_id: Some(time_serie.external_id.into()),
+            metadata: Some(time_serie.metadata.into()),
+            unit: Some(time_serie.unit.into()),
             asset_id: Some(time_serie.asset_id.into()),
-            description: Some(time_serie.description.clone().into()),
-            security_categories: Some(time_serie.security_categories.clone().into()),
+            description: Some(time_serie.description.into()),
+            security_categories: Some(time_serie.security_categories.into()),
             data_set_id: Some(time_serie.data_set_id.into()),
             is_step: Some(time_serie.is_step.into()),
         }

--- a/cognite/src/dto/data_ingestion/extpipes.rs
+++ b/cognite/src/dto/data_ingestion/extpipes.rs
@@ -1,30 +1,29 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{Identity, Patch, Range, UpdateList, UpdateMap, UpdateSet};
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeRawTable {
     pub db_name: String,
     pub table_name: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, Default, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeContact {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub send_notification: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipe {
     pub id: i64,
@@ -47,105 +46,90 @@ pub struct ExtPipe {
     pub created_by: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddExtPipe {
     pub external_id: String,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub data_set_id: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_tables: Option<Vec<ExtPipeRawTable>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub schedule: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contacts: Option<Vec<ExtPipeContact>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<String>,
 }
 
-impl From<&ExtPipe> for AddExtPipe {
-    fn from(pipe: &ExtPipe) -> Self {
+impl From<ExtPipe> for AddExtPipe {
+    fn from(pipe: ExtPipe) -> Self {
         AddExtPipe {
-            external_id: pipe.external_id.clone(),
-            name: pipe.name.clone(),
-            description: pipe.description.clone(),
+            external_id: pipe.external_id,
+            name: pipe.name,
+            description: pipe.description,
             data_set_id: pipe.data_set_id,
-            raw_tables: pipe.raw_tables.clone(),
-            schedule: pipe.schedule.clone(),
-            contacts: pipe.contacts.clone(),
-            metadata: pipe.metadata.clone(),
-            source: pipe.source.clone(),
-            documentation: pipe.documentation.clone(),
+            raw_tables: pipe.raw_tables,
+            schedule: pipe.schedule,
+            contacts: pipe.contacts,
+            metadata: pipe.metadata,
+            source: pipe.source,
+            documentation: pipe.documentation,
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchExtPipe {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSet<Option<String>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSet<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub schedule: Option<UpdateSet<Option<String>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_tables: Option<UpdateList<ExtPipeRawTable, ExtPipeRawTable>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contacts: Option<UpdateList<ExtPipeContact, ExtPipeContact>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<UpdateSet<Option<String>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<UpdateSet<Option<String>>>,
 }
 
-impl From<&ExtPipe> for Patch<PatchExtPipe> {
-    fn from(pipe: &ExtPipe) -> Self {
+impl From<ExtPipe> for Patch<PatchExtPipe> {
+    fn from(pipe: ExtPipe) -> Self {
         Patch::<PatchExtPipe> {
             id: Identity::ExternalId {
                 external_id: pipe.external_id.clone(),
             },
             update: PatchExtPipe {
-                external_id: Some(pipe.external_id.clone().into()),
-                name: Some(pipe.name.clone().into()),
-                description: Some(pipe.description.clone().into()),
+                external_id: Some(pipe.external_id.into()),
+                name: Some(pipe.name.into()),
+                description: Some(pipe.description.into()),
                 data_set_id: Some(pipe.data_set_id.into()),
-                schedule: Some(pipe.schedule.clone().into()),
-                raw_tables: Some(pipe.raw_tables.clone().into()),
-                contacts: Some(pipe.contacts.clone().into()),
-                metadata: Some(pipe.metadata.clone().into()),
-                source: Some(pipe.source.clone().into()),
-                documentation: Some(pipe.documentation.clone().into()),
+                schedule: Some(pipe.schedule.into()),
+                raw_tables: Some(pipe.raw_tables.into()),
+                contacts: Some(pipe.contacts.into()),
+                metadata: Some(pipe.metadata.into()),
+                source: Some(pipe.source.into()),
+                documentation: Some(pipe.documentation.into()),
             },
         }
     }
 }
 
-impl From<&AddExtPipe> for PatchExtPipe {
-    fn from(pipe: &AddExtPipe) -> Self {
+impl From<AddExtPipe> for PatchExtPipe {
+    fn from(pipe: AddExtPipe) -> Self {
         PatchExtPipe {
-            external_id: Some(pipe.external_id.clone().into()),
-            name: Some(pipe.name.clone().into()),
-            description: Some(pipe.description.clone().into()),
+            external_id: Some(pipe.external_id.into()),
+            name: Some(pipe.name.into()),
+            description: Some(pipe.description.into()),
             data_set_id: Some(pipe.data_set_id.into()),
-            schedule: Some(pipe.schedule.clone().into()),
-            raw_tables: Some(pipe.raw_tables.clone().into()),
-            contacts: Some(pipe.contacts.clone().into()),
-            metadata: Some(pipe.metadata.clone().into()),
-            source: Some(pipe.source.clone().into()),
-            documentation: Some(pipe.documentation.clone().into()),
+            schedule: Some(pipe.schedule.into()),
+            raw_tables: Some(pipe.raw_tables.into()),
+            contacts: Some(pipe.contacts.into()),
+            metadata: Some(pipe.metadata.into()),
+            source: Some(pipe.source.into()),
+            documentation: Some(pipe.documentation.into()),
         }
     }
 }
@@ -164,36 +148,25 @@ impl Default for ExtPipeRunStatus {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct ExtPipeFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub schedule: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub contacts: Option<Vec<ExtPipeContact>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_tables: Option<Vec<ExtPipeRawTable>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_by: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeRun {
@@ -204,13 +177,12 @@ pub struct ExtPipeRun {
     pub external_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AddExtPipeRun {
     pub status: ExtPipeRunStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<i64>,
     pub external_id: String,
 }
@@ -221,14 +193,12 @@ pub struct ExtPipeStringFilter {
     pub substring: String,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtPipeRunFilter {
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub statuses: Option<Vec<ExtPipeRunStatus>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<ExtPipeStringFilter>,
 }

--- a/cognite/src/dto/data_ingestion/raw.rs
+++ b/cognite/src/dto/data_ingestion/raw.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{to_query, AsParams, SetCursor};
 
@@ -21,7 +22,7 @@ pub struct Table {
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RawRow {
     pub key: String,
@@ -29,13 +30,13 @@ pub struct RawRow {
     pub last_updated_time: i64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RawRowCreate {
     pub key: String,
     pub columns: ::serde_json::Value,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeleteRow {
     pub key: String,
 }
@@ -65,17 +66,13 @@ impl AsParams for RetrieveCursorsQuery {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct RetrieveRowsQuery {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_last_updated_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_last_updated_time: Option<i64>,
 }
 

--- a/cognite/src/dto/data_modeling/common.rs
+++ b/cognite/src/dto/data_modeling/common.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::models::ViewReference;
 
@@ -9,12 +10,12 @@ pub struct ItemId {
     pub external_id: String,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemIdOptionalVersion {
     pub space: String,
     pub external_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 }
 

--- a/cognite/src/dto/data_organization/datasets.rs
+++ b/cognite/src/dto/data_organization/datasets.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{Identity, Patch, Range, UpdateMap, UpdateSet, UpdateSetNull};
 
@@ -17,44 +18,37 @@ pub struct DataSet {
     pub write_protected: bool,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AddDataSet {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
     pub write_protected: bool,
 }
 
-impl From<&DataSet> for AddDataSet {
-    fn from(dataset: &DataSet) -> Self {
+impl From<DataSet> for AddDataSet {
+    fn from(dataset: DataSet) -> Self {
         AddDataSet {
-            external_id: dataset.external_id.clone(),
-            name: dataset.name.clone(),
-            description: dataset.description.clone(),
-            metadata: dataset.metadata.clone(),
+            external_id: dataset.external_id,
+            name: dataset.name,
+            description: dataset.description,
+            metadata: dataset.metadata,
             write_protected: dataset.write_protected,
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DataSetFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub write_protected: Option<bool>,
 }
 
@@ -64,43 +58,39 @@ pub struct DataSetsCount {
     pub count: i64,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchDataSet {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<UpdateSetNull<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<UpdateMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub write_protected: Option<UpdateSet<bool>>,
 }
 
-impl From<&DataSet> for Patch<PatchDataSet> {
-    fn from(data_set: &DataSet) -> Patch<PatchDataSet> {
+impl From<DataSet> for Patch<PatchDataSet> {
+    fn from(data_set: DataSet) -> Patch<PatchDataSet> {
         Patch::<PatchDataSet> {
             id: to_idt!(data_set),
             update: PatchDataSet {
-                external_id: Some(data_set.external_id.clone().into()),
-                name: Some(data_set.name.clone().into()),
-                description: Some(data_set.description.clone().into()),
-                metadata: Some(data_set.metadata.clone().into()),
+                external_id: Some(data_set.external_id.into()),
+                name: Some(data_set.name.into()),
+                description: Some(data_set.description.into()),
+                metadata: Some(data_set.metadata.into()),
                 write_protected: Some(data_set.write_protected.into()),
             },
         }
     }
 }
 
-impl From<&AddDataSet> for PatchDataSet {
-    fn from(data_set: &AddDataSet) -> Self {
+impl From<AddDataSet> for PatchDataSet {
+    fn from(data_set: AddDataSet) -> Self {
         PatchDataSet {
-            external_id: Some(data_set.external_id.clone().into()),
-            name: Some(data_set.name.clone().into()),
-            description: Some(data_set.description.clone().into()),
-            metadata: Some(data_set.metadata.clone().into()),
+            external_id: Some(data_set.external_id.into()),
+            name: Some(data_set.name.into()),
+            description: Some(data_set.description.into()),
+            metadata: Some(data_set.metadata.into()),
             write_protected: Some(data_set.write_protected.into()),
         }
     }

--- a/cognite/src/dto/data_organization/labels.rs
+++ b/cognite/src/dto/data_organization/labels.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::Identity;
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Label {
     pub external_id: String,
@@ -12,35 +14,32 @@ pub struct Label {
     pub created_time: i64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddLabel {
     pub external_id: String,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
 }
 
-impl From<&Label> for AddLabel {
-    fn from(label: &Label) -> Self {
+impl From<Label> for AddLabel {
+    fn from(label: Label) -> Self {
         AddLabel {
-            external_id: label.external_id.clone(),
-            name: label.name.clone(),
-            description: label.description.clone(),
+            external_id: label.external_id,
+            name: label.name,
+            description: label.description,
             data_set_id: label.data_set_id,
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LabelFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id_prefix: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
 }

--- a/cognite/src/dto/data_organization/relationships.rs
+++ b/cognite/src/dto/data_organization/relationships.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 use crate::{
     CogniteExternalId, Identity, LabelsFilter, Partition, Patch, Range, SetCursor, UpdateList,
@@ -29,6 +30,7 @@ pub enum RelationshipVertex {
     Sequence(()),
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Relationship {
@@ -37,26 +39,18 @@ pub struct Relationship {
     pub source_type: RelationshipVertexType,
     pub target_external_id: String,
     pub target_type: RelationshipVertexType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<CogniteExternalId>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<RelationshipVertex>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<RelationshipVertex>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AddRelationship {
@@ -65,91 +59,78 @@ pub struct AddRelationship {
     pub source_type: RelationshipVertexType,
     pub target_external_id: String,
     pub target_type: RelationshipVertexType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<CogniteExternalId>>,
 }
 
-impl From<&Relationship> for AddRelationship {
-    fn from(rel: &Relationship) -> Self {
+impl From<Relationship> for AddRelationship {
+    fn from(rel: Relationship) -> Self {
         AddRelationship {
-            external_id: rel.external_id.clone(),
-            source_external_id: rel.source_external_id.clone(),
+            external_id: rel.external_id,
+            source_external_id: rel.source_external_id,
             source_type: rel.source_type,
-            target_external_id: rel.target_external_id.clone(),
+            target_external_id: rel.target_external_id,
             target_type: rel.target_type,
             start_time: rel.start_time,
             end_time: rel.end_time,
             confidence: rel.confidence,
             data_set_id: rel.data_set_id,
-            labels: rel.labels.clone(),
+            labels: rel.labels,
         }
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchRelationship {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_type: Option<UpdateSet<RelationshipVertexType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_external_id: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_type: Option<UpdateSet<RelationshipVertexType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_external_id: Option<UpdateSet<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<UpdateSetNull<f32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_id: Option<UpdateSetNull<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<UpdateList<CogniteExternalId, CogniteExternalId>>,
 }
 
-impl From<&Relationship> for Patch<PatchRelationship> {
-    fn from(rel: &Relationship) -> Self {
+impl From<Relationship> for Patch<PatchRelationship> {
+    fn from(rel: Relationship) -> Self {
         Patch::<PatchRelationship> {
             id: Identity::ExternalId {
-                external_id: rel.external_id.clone(),
+                external_id: rel.external_id,
             },
             update: PatchRelationship {
                 source_type: Some(rel.source_type.into()),
-                source_external_id: Some(rel.source_external_id.clone().into()),
+                source_external_id: Some(rel.source_external_id.into()),
                 target_type: Some(rel.target_type.into()),
-                target_external_id: Some(rel.target_external_id.clone().into()),
+                target_external_id: Some(rel.target_external_id.into()),
                 confidence: Some(rel.confidence.into()),
                 start_time: Some(rel.start_time.into()),
                 end_time: Some(rel.end_time.into()),
                 data_set_id: Some(rel.data_set_id.into()),
-                labels: Some(rel.labels.clone().into()),
+                labels: Some(rel.labels.into()),
             },
         }
     }
 }
 
-impl From<&AddRelationship> for PatchRelationship {
-    fn from(rel: &AddRelationship) -> Self {
+impl From<AddRelationship> for PatchRelationship {
+    fn from(rel: AddRelationship) -> Self {
         PatchRelationship {
             source_type: Some(rel.source_type.into()),
-            source_external_id: Some(rel.source_external_id.clone().into()),
+            source_external_id: Some(rel.source_external_id.into()),
             target_type: Some(rel.target_type.into()),
-            target_external_id: Some(rel.target_external_id.clone().into()),
+            target_external_id: Some(rel.target_external_id.into()),
             confidence: Some(rel.confidence.into()),
             start_time: Some(rel.start_time.into()),
             end_time: Some(rel.end_time.into()),
             data_set_id: Some(rel.data_set_id.into()),
-            labels: Some(rel.labels.clone().into()),
+            labels: Some(rel.labels.into()),
         }
     }
 }
@@ -189,48 +170,33 @@ pub struct SourceOrTargetFilter {
     pub external_id: String,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RelationshipsFilter {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_types: Option<Vec<RelationshipVertexType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_external_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target_types: Option<Vec<RelationshipVertexType>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_set_ids: Option<Vec<Identity>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub end_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub confidence: Option<Range<f64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_updated_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub active_at_time: Option<Range<i64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sources_or_targets: Option<Vec<SourceOrTargetFilter>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<LabelsFilter>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterRelationshipsQuery {
     pub filter: RelationshipsFilter,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub fetch_resources: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<Partition>,
 }
 

--- a/cognite/src/dto/filter_types.rs
+++ b/cognite/src/dto/filter_types.rs
@@ -1,15 +1,15 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::CogniteExternalId;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Range<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min: Option<T>,
 }
 
@@ -19,13 +19,12 @@ impl<T> Range<T> {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Filter<T> {
     pub filter: T,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }
 
@@ -45,12 +44,12 @@ impl<T> SetCursor for Filter<T> {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Search<TFilter, TSearch> {
     pub filter: TFilter,
     pub search: TSearch,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }
 
@@ -101,15 +100,13 @@ impl Serialize for Partition {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PartitionedFilter<T> {
     pub filter: T,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<Partition>,
 }
 

--- a/cognite/src/dto/iam/group.rs
+++ b/cognite/src/dto/iam/group.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{to_query, AsParams};
 
@@ -12,7 +13,8 @@ pub struct GroupListResponse {
     next_cursor: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Group {
     pub id: u64,
@@ -24,7 +26,8 @@ pub struct Group {
     pub metadata: Option<HashMap<String, String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddGroup {
     pub name: String,
@@ -33,13 +36,13 @@ pub struct AddGroup {
     pub metadata: Option<HashMap<String, String>>,
 }
 
-impl From<&Group> for AddGroup {
-    fn from(value: &Group) -> Self {
+impl From<Group> for AddGroup {
+    fn from(value: Group) -> Self {
         Self {
-            name: value.name.clone(),
-            source_id: value.source_id.clone(),
-            capabilities: value.capabilities.clone(),
-            metadata: value.metadata.clone(),
+            name: value.name,
+            source_id: value.source_id,
+            capabilities: value.capabilities,
+            metadata: value.metadata,
         }
     }
 }

--- a/cognite/src/dto/iam/security_category.rs
+++ b/cognite/src/dto/iam/security_category.rs
@@ -1,9 +1,11 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{to_query, AsParams};
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityCategoryListResponse {
@@ -12,7 +14,8 @@ pub struct SecurityCategoryListResponse {
     next_cursor: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityCategory {
     pub name: String,

--- a/cognite/src/dto/iam/session.rs
+++ b/cognite/src/dto/iam/session.rs
@@ -1,10 +1,11 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{to_query, AsParams, SetCursor};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
     Ready,
@@ -48,7 +49,8 @@ impl AsParams for SessionQuery {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {
     pub id: i64,

--- a/cognite/src/dto/items.rs
+++ b/cognite/src/dto/items.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -31,6 +32,7 @@ impl<T: Serialize> From<&[T]> for Items {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ItemsWithCursor<T>

--- a/cognite/src/dto/patch_item.rs
+++ b/cognite/src/dto/patch_item.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use crate::{EqIdentity, Identity};
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSetNull<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set_null: Option<bool>,
 }
 
@@ -28,10 +28,10 @@ impl<T> From<Option<T>> for UpdateSetNull<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSet<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set: Option<T>,
 }
 
@@ -41,14 +41,12 @@ impl<T> From<T> for UpdateSet<T> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateList<TAdd, TRemove> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub add: Option<Vec<TAdd>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub remove: Option<Vec<TRemove>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set: Option<Vec<TAdd>>,
 }
 
@@ -75,17 +73,15 @@ impl<TAdd, TRemove> From<Option<Vec<TAdd>>> for UpdateList<TAdd, TRemove> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateMap<TKey, TValue>
 where
     TKey: std::hash::Hash + std::cmp::Eq,
 {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub set: Option<HashMap<TKey, TValue>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub remove: Option<Vec<TKey>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub add: Option<HashMap<TKey, TValue>>,
 }
 


### PR DESCRIPTION
 - Use skip_serialize_none for cleaner code
 - Use From\<T\> instead of From<&T> for conversions. It is good practice to leave the cloning to the user.