### PR TITLE
Make "version" field of DataModelId optional

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 edition = "2018"
 name = "cognite"
 publish = false
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies]
 async-trait = "0.1.74"

--- a/cognite/src/dto/data_modeling/data_models.rs
+++ b/cognite/src/dto/data_modeling/data_models.rs
@@ -48,12 +48,13 @@ pub struct DataModel {
     pub is_global: bool,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DataModelId {
     pub space: String,
     pub external_id: String,
-    pub version: String,
+    pub version: Option<String>,
 }
 
 #[skip_serializing_none]

--- a/cognite/tests/instances_tests.rs
+++ b/cognite/tests/instances_tests.rs
@@ -68,10 +68,7 @@ async fn create_and_delete_instances() {
     assert_eq!(
         result
             .iter()
-            .filter(|&x| match x {
-                SlimNodeOrEdge::Node(_) => true,
-                _ => false,
-            })
+            .filter(|&x| matches!(x, SlimNodeOrEdge::Node(_)))
             .count(),
         node_external_ids.len()
     );
@@ -79,10 +76,7 @@ async fn create_and_delete_instances() {
     assert_eq!(
         result
             .iter()
-            .filter(|&x| match x {
-                SlimNodeOrEdge::Edge(_) => true,
-                _ => false,
-            })
+            .filter(|&x| matches!(x, SlimNodeOrEdge::Edge(_)))
             .count(),
         edge_external_ids.len()
     );


### PR DESCRIPTION
The [retrieve data models endpoint](https://api-docs.cognite.com/20230101/tag/Data-models/operation/byExternalIdsDataModels) does not require the `version` field in the request, so I believe it should be optional in the `DataModelId` as well.

(This PR also includes fixes for some minor `cargo clippy` warnings.)