### PR TITLE
Use native async trait

### DIFF
--- a/cognite/src/api/mod.rs
+++ b/cognite/src/api/mod.rs
@@ -8,5 +8,3 @@ pub mod data_organization;
 pub mod iam;
 pub mod resource;
 pub mod utils;
-
-pub use self::api_client::*;

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -1,8 +1,7 @@
 use std::collections::VecDeque;
-use std::pin::Pin;
+use std::future::Future;
 use std::{marker::PhantomData, sync::Arc};
 
-use async_trait::async_trait;
 use futures::future::try_join_all;
 use futures::stream::try_unfold;
 use futures::TryStream;
@@ -52,41 +51,47 @@ pub trait WithBasePath {
     const BASE_PATH: &'static str;
 }
 
-#[async_trait]
 /// Trait for simple GET / endpoints.
 pub trait List<TParams, TResponse>
 where
     TParams: AsParams + Send + Sync + 'static,
     TResponse: Serialize + DeserializeOwned + Send + Sync,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Query a resource with optional query parameters.
-    async fn list(&self, params: Option<TParams>) -> Result<ItemsWithCursor<TResponse>> {
-        Ok(self
-            .get_client()
-            .get_with_params(Self::BASE_PATH, params)
-            .await?)
+    fn list(
+        &self,
+        params: Option<TParams>,
+    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+        async move {
+            Ok(self
+                .get_client()
+                .get_with_params(Self::BASE_PATH, params)
+                .await?)
+        }
     }
 
     /// Query a resource with query parameters, continuing until the cursor is exhausted.
-    async fn list_all(&self, mut params: TParams) -> Result<Vec<TResponse>>
+    fn list_all(&self, mut params: TParams) -> impl Future<Output = Result<Vec<TResponse>>> + Send
     where
         TParams: SetCursor + Clone,
         TResponse: Send,
     {
-        let mut result = vec![];
-        loop {
-            let lparams = params.clone();
-            let response: ItemsWithCursor<TResponse> = self
-                .get_client()
-                .get_with_params(Self::BASE_PATH, Some(lparams))
-                .await?;
-            for it in response.items {
-                result.push(it);
-            }
-            match response.next_cursor {
-                Some(cursor) => params.set_cursor(Some(cursor)),
-                None => return Ok(result),
+        async move {
+            let mut result = vec![];
+            loop {
+                let lparams = params.clone();
+                let response: ItemsWithCursor<TResponse> = self
+                    .get_client()
+                    .get_with_params(Self::BASE_PATH, Some(lparams))
+                    .await?;
+                for it in response.items {
+                    result.push(it);
+                }
+                match response.next_cursor {
+                    Some(cursor) => params.set_cursor(Some(cursor)),
+                    None => return Ok(result),
+                }
             }
         }
     }
@@ -99,7 +104,7 @@ where
     fn list_all_stream<'a>(
         &'a self,
         params: TParams,
-    ) -> Pin<Box<dyn TryStream<Ok = TResponse, Error = crate::Error, Item = Result<TResponse>> + 'a>>
+    ) -> impl TryStream<Ok = TResponse, Error = crate::Error, Item = Result<TResponse>> + Send + 'a
     where
         TParams: SetCursor + Clone,
         TResponse: Send + 'static,
@@ -110,7 +115,7 @@ where
             next_cursor: CursorState::Initial,
         };
 
-        Box::pin(try_unfold(state, move |mut state| async move {
+        try_unfold(state, move |mut state| async move {
             if let Some(next) = state.responses.pop_front() {
                 Ok(Some((next, state)))
             } else {
@@ -138,400 +143,449 @@ where
                     Ok(None)
                 }
             }
-        }))
+        })
     }
 }
 
-#[async_trait]
 /// Trait for creating resources with POST / requests.
 pub trait Create<TCreate, TResponse>
 where
     TCreate: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Create a list of resources.
-    async fn create(&self, creates: &[TCreate]) -> Result<Vec<TResponse>> {
-        let items = Items::from(creates);
-        let response: ItemsWithoutCursor<TResponse> =
-            self.get_client().post(Self::BASE_PATH, &items).await?;
-        Ok(response.items)
-    }
-
-    /// Create a list of resources, converting from a different type.
-    async fn create_from<'a>(
-        &self,
-        creates: &'a [impl Into<TCreate> + Sync + Clone],
-    ) -> Result<Vec<TResponse>> {
-        let to_add: Vec<TCreate> = creates.iter().map(|i| i.clone().into()).collect();
-        self.create(&to_add).await
-    }
-
-    /// Create a list of resources, ignoring any that fail with general "conflict" errors.
-    async fn create_ignore_duplicates(&self, creates: &[TCreate]) -> Result<Vec<TResponse>>
-    where
-        TCreate: EqIdentity,
-    {
-        let resp = self.create(creates).await;
-
-        let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
-
-        if let Some(duplicates) = duplicates {
-            let next: Vec<&TCreate> = creates
-                .iter()
-                .filter(|c| !duplicates.iter().any(|i| c.eq(i)))
-                .collect();
-
-            if next.is_empty() {
-                if duplicates.len() == creates.len() {
-                    return Ok(vec![]);
-                }
-                return resp;
-            }
-
-            let items = Items::from(next);
+    fn create(&self, creates: &[TCreate]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let items = Items::from(creates);
             let response: ItemsWithoutCursor<TResponse> =
                 self.get_client().post(Self::BASE_PATH, &items).await?;
             Ok(response.items)
-        } else {
-            resp
+        }
+    }
+
+    /// Create a list of resources, converting from a different type.
+    fn create_from<'a>(
+        &self,
+        creates: &'a [impl Into<TCreate> + Sync + Clone],
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let to_add: Vec<TCreate> = creates.iter().map(|i| i.clone().into()).collect();
+            self.create(&to_add).await
+        }
+    }
+
+    /// Create a list of resources, ignoring any that fail with general "conflict" errors.
+    fn create_ignore_duplicates(
+        &self,
+        creates: &[TCreate],
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
+    where
+        TCreate: EqIdentity,
+    {
+        async move {
+            let resp = self.create(creates).await;
+
+            let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
+
+            if let Some(duplicates) = duplicates {
+                let next: Vec<&TCreate> = creates
+                    .iter()
+                    .filter(|c| !duplicates.iter().any(|i| c.eq(i)))
+                    .collect();
+
+                if next.is_empty() {
+                    if duplicates.len() == creates.len() {
+                        return Ok(vec![]);
+                    }
+                    return resp;
+                }
+
+                let items = Items::from(next);
+                let response: ItemsWithoutCursor<TResponse> =
+                    self.get_client().post(Self::BASE_PATH, &items).await?;
+                Ok(response.items)
+            } else {
+                resp
+            }
         }
     }
 
     /// Create a list of resources, converting from a different type, and ignoring any that fail
     /// with general "conflict" errors.
-    async fn create_from_ignore_duplicates<T: 'a, 'a>(
+    fn create_from_ignore_duplicates<'a, T: 'a>(
         &self,
         creates: &'a [impl Into<TCreate> + Sync + Clone],
-    ) -> Result<Vec<TResponse>>
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
     where
         TCreate: EqIdentity,
     {
-        let to_add: Vec<TCreate> = creates.iter().map(|i| i.clone().into()).collect();
-        self.create_ignore_duplicates(&to_add).await
+        async move {
+            let to_add: Vec<TCreate> = creates.iter().map(|i| i.clone().into()).collect();
+            self.create_ignore_duplicates(&to_add).await
+        }
     }
 }
 
-#[async_trait]
 /// Trait for upserts of resources that support both Create and Update.
-pub trait Upsert<TCreate, TUpdate, TResponse, 'a>
+pub trait Upsert<'a, TCreate, TUpdate, TResponse>
 where
     TCreate: Serialize + Sync + Send + EqIdentity + 'a + Clone + IntoPatch<TUpdate>,
     TUpdate: Serialize + Sync + Send + Default,
     TResponse: Serialize + DeserializeOwned + Sync + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Upsert a list resources, meaning that they will first be attempted created,
     /// and if that fails with a conflict, update any that already existed, and create
     /// the remainder.
-    async fn upsert(
+    fn upsert(
         &'a self,
         upserts: &'a [TCreate],
         ignore_nulls: bool,
-    ) -> Result<Vec<TResponse>> {
-        let items = Items::from(upserts);
-        let resp: Result<ItemsWithoutCursor<TResponse>> =
-            self.get_client().post(Self::BASE_PATH, &items).await;
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let items = Items::from(upserts);
+            let resp: Result<ItemsWithoutCursor<TResponse>> =
+                self.get_client().post(Self::BASE_PATH, &items).await;
 
-        let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
+            let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
 
-        if let Some(duplicates) = duplicates {
-            let mut to_create = Vec::with_capacity(upserts.len() - duplicates.len());
-            let mut to_update = Vec::with_capacity(duplicates.len());
-            for it in upserts {
-                let idt = duplicates.iter().find(|i| it.eq(i));
-                if let Some(idt) = idt {
-                    to_update.push(Patch::<TUpdate> {
-                        id: idt.clone(),
-                        update: it.clone().patch(ignore_nulls),
-                    });
-                } else {
-                    to_create.push(it);
+            if let Some(duplicates) = duplicates {
+                let mut to_create = Vec::with_capacity(upserts.len() - duplicates.len());
+                let mut to_update = Vec::with_capacity(duplicates.len());
+                for it in upserts {
+                    let idt = duplicates.iter().find(|i| it.eq(i));
+                    if let Some(idt) = idt {
+                        to_update.push(Patch::<TUpdate> {
+                            id: idt.clone(),
+                            update: it.clone().patch(ignore_nulls),
+                        });
+                    } else {
+                        to_create.push(it);
+                    }
                 }
-            }
 
-            let mut result = Vec::with_capacity(to_create.len() + to_update.len());
-            if !to_create.is_empty() {
-                let mut create_response: ItemsWithoutCursor<TResponse> = self
-                    .get_client()
-                    .post(Self::BASE_PATH, &Items::from(to_create))
-                    .await?;
-                result.append(&mut create_response.items);
-            }
-            if !to_update.is_empty() {
-                let mut update_response: ItemsWithoutCursor<TResponse> = self
-                    .get_client()
-                    .post(
-                        &format!("{}/update", Self::BASE_PATH),
-                        &Items::from(&to_update),
-                    )
-                    .await?;
-                result.append(&mut update_response.items);
-            }
+                let mut result = Vec::with_capacity(to_create.len() + to_update.len());
+                if !to_create.is_empty() {
+                    let mut create_response: ItemsWithoutCursor<TResponse> = self
+                        .get_client()
+                        .post(Self::BASE_PATH, &Items::from(to_create))
+                        .await?;
+                    result.append(&mut create_response.items);
+                }
+                if !to_update.is_empty() {
+                    let mut update_response: ItemsWithoutCursor<TResponse> = self
+                        .get_client()
+                        .post(
+                            &format!("{}/update", Self::BASE_PATH),
+                            &Items::from(&to_update),
+                        )
+                        .await?;
+                    result.append(&mut update_response.items);
+                }
 
-            Ok(result)
-        } else {
-            resp.map(|i| i.items)
+                Ok(result)
+            } else {
+                resp.map(|i| i.items)
+            }
         }
     }
 }
 
 impl<'a, T, TCreate, TUpdate, TResponse> Upsert<'a, TCreate, TUpdate, TResponse> for T
 where
-    T: Create<TCreate, TResponse> + Update<Patch<TUpdate>, TResponse>,
+    T: Create<TCreate, TResponse> + Update<Patch<TUpdate>, TResponse> + Sync,
     TCreate: Serialize + Sync + Send + EqIdentity + 'a + Clone + IntoPatch<TUpdate>,
     TUpdate: Serialize + Sync + Send + Default,
     TResponse: Serialize + DeserializeOwned + Sync + Send,
 {
 }
 
-#[async_trait]
 /// Trait for resource types that support upserts directly.
 pub trait UpsertCollection<TUpsert, TResponse> {
     /// Upsert a list of resources.
-    async fn upsert(&self, collection: &TUpsert) -> Result<Vec<TResponse>>
+    fn upsert(&self, collection: &TUpsert) -> impl Future<Output = Result<Vec<TResponse>>> + Send
     where
         TUpsert: Serialize + Sync + Send,
         TResponse: Serialize + DeserializeOwned + Sync + Send,
-        Self: WithApiClient + WithBasePath,
+        Self: WithApiClient + WithBasePath + Sync,
     {
-        let response: ItemsWithoutCursor<TResponse> =
-            self.get_client().post(Self::BASE_PATH, &collection).await?;
-        Ok(response.items)
+        async move {
+            let response: ItemsWithoutCursor<TResponse> =
+                self.get_client().post(Self::BASE_PATH, &collection).await?;
+            Ok(response.items)
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that can be deleted with a list of `TIdt`.
 pub trait Delete<TIdt>
 where
     TIdt: Serialize + Sync + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Delete a list of resources by ID.
-    async fn delete(&self, deletes: &[TIdt]) -> Result<()> {
-        let items = Items::from(deletes);
-        self.get_client()
-            .post::<::serde_json::Value, Items<&[TIdt]>>(
-                &format!("{}/delete", Self::BASE_PATH),
-                &items,
-            )
-            .await?;
-        Ok(())
+    fn delete(&self, deletes: &[TIdt]) -> impl Future<Output = Result<()>> + Send {
+        async move {
+            let items = Items::from(deletes);
+            self.get_client()
+                .post::<::serde_json::Value, Items<&[TIdt]>>(
+                    &format!("{}/delete", Self::BASE_PATH),
+                    &items,
+                )
+                .await?;
+            Ok(())
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that can be deleted with a more complex request.
 pub trait DeleteWithRequest<TReq>
 where
     TReq: Serialize + Sync + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Delete resources using `req`.
-    async fn delete(&self, req: &TReq) -> Result<()> {
-        self.get_client()
-            .post::<::serde_json::Value, TReq>(&format!("{}/delete", Self::BASE_PATH), req)
-            .await?;
-        Ok(())
+    fn delete(&self, req: &TReq) -> impl Future<Output = Result<()>> + Send {
+        async move {
+            self.get_client()
+                .post::<::serde_json::Value, TReq>(&format!("{}/delete", Self::BASE_PATH), req)
+                .await?;
+            Ok(())
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that can be deleted with a list of identities and
 /// a boolean option to ignore unknown ids.
 pub trait DeleteWithIgnoreUnknownIds<TIdt>
 where
     TIdt: Serialize + Sync + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Delete a list of resources, optionally ignore unknown ids.
-    async fn delete(&self, deletes: &[TIdt], ignore_unknown_ids: bool) -> Result<()> {
-        let mut req = ItemsWithIgnoreUnknownIds::from(deletes);
-        req.ignore_unknown_ids = ignore_unknown_ids;
-        self.get_client()
-            .post::<::serde_json::Value, _>(&format!("{}/delete", Self::BASE_PATH), &req)
-            .await?;
-        Ok(())
+    fn delete(
+        &self,
+        deletes: &[TIdt],
+        ignore_unknown_ids: bool,
+    ) -> impl Future<Output = Result<()>> + Send
+    where
+        Self: Sync,
+    {
+        async move {
+            let mut req = ItemsWithIgnoreUnknownIds::from(deletes);
+            req.ignore_unknown_ids = ignore_unknown_ids;
+            self.get_client()
+                .post::<::serde_json::Value, _>(&format!("{}/delete", Self::BASE_PATH), &req)
+                .await?;
+            Ok(())
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that can be deleted, and where the delete request
 /// has a non-empty response.
 pub trait DeleteWithResponse<TIdt, TResponse>
 where
     TIdt: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned + Sync + Send,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Delete a list of resources.
-    async fn delete(&self, deletes: &[TIdt]) -> Result<ItemsWithoutCursor<TResponse>> {
-        let items = Items::from(deletes);
-        let response: ItemsWithoutCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/delete", Self::BASE_PATH), &items)
-            .await?;
-        Ok(response)
+    fn delete(
+        &self,
+        deletes: &[TIdt],
+    ) -> impl Future<Output = Result<ItemsWithoutCursor<TResponse>>> + Send {
+        async move {
+            let items = Items::from(deletes);
+            let response: ItemsWithoutCursor<TResponse> = self
+                .get_client()
+                .post(&format!("{}/delete", Self::BASE_PATH), &items)
+                .await?;
+            Ok(response)
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that can be patch updated.
 pub trait Update<TUpdate, TResponse>
 where
     TUpdate: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Update a list of resources.
-    async fn update(&self, updates: &[TUpdate]) -> Result<Vec<TResponse>> {
-        let items = Items::from(updates);
-        let response: ItemsWithoutCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/update", Self::BASE_PATH), &items)
-            .await?;
-        Ok(response.items)
-    }
-
-    /// Update a list of resources by converting to the update from a different type.
-    async fn update_from<T: 'a, 'a>(&self, updates: &'a [T]) -> Result<Vec<TResponse>>
-    where
-        T: std::marker::Sync + Clone,
-        TUpdate: From<T>,
-    {
-        let to_update: Vec<TUpdate> = updates.iter().map(|i| TUpdate::from(i.clone())).collect();
-        self.update(&to_update).await
-    }
-
-    /// Update a list of resources, ignoring any that fail due to items missing in CDF.
-    async fn update_ignore_unknown_ids(&self, updates: &[TUpdate]) -> Result<Vec<TResponse>>
-    where
-        TUpdate: EqIdentity,
-        TResponse: Send,
-    {
-        let response = self.update(updates).await;
-        let missing: Option<Vec<Identity>> = get_missing_from_result(&response);
-
-        if let Some(missing) = missing {
-            let next: Vec<&TUpdate> = updates
-                .iter()
-                .filter(|c| !missing.iter().any(|i| c.eq(i)))
-                .collect();
-
-            if next.is_empty() {
-                if missing.len() == updates.len() {
-                    return Ok(vec![]);
-                }
-                return response;
-            }
-
-            let items = Items::from(next);
+    fn update(&self, updates: &[TUpdate]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let items = Items::from(updates);
             let response: ItemsWithoutCursor<TResponse> = self
                 .get_client()
                 .post(&format!("{}/update", Self::BASE_PATH), &items)
                 .await?;
             Ok(response.items)
-        } else {
-            response
+        }
+    }
+
+    /// Update a list of resources by converting to the update from a different type.
+    fn update_from<'a, T: 'a>(
+        &self,
+        updates: &'a [T],
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
+    where
+        T: std::marker::Sync + Clone,
+        TUpdate: From<T>,
+    {
+        async move {
+            let to_update: Vec<TUpdate> =
+                updates.iter().map(|i| TUpdate::from(i.clone())).collect();
+            self.update(&to_update).await
+        }
+    }
+
+    /// Update a list of resources, ignoring any that fail due to items missing in CDF.
+    fn update_ignore_unknown_ids(
+        &self,
+        updates: &[TUpdate],
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
+    where
+        TUpdate: EqIdentity,
+        TResponse: Send,
+    {
+        async move {
+            let response = self.update(updates).await;
+            let missing: Option<Vec<Identity>> = get_missing_from_result(&response);
+
+            if let Some(missing) = missing {
+                let next: Vec<&TUpdate> = updates
+                    .iter()
+                    .filter(|c| !missing.iter().any(|i| c.eq(i)))
+                    .collect();
+
+                if next.is_empty() {
+                    if missing.len() == updates.len() {
+                        return Ok(vec![]);
+                    }
+                    return response;
+                }
+
+                let items = Items::from(next);
+                let response: ItemsWithoutCursor<TResponse> = self
+                    .get_client()
+                    .post(&format!("{}/update", Self::BASE_PATH), &items)
+                    .await?;
+                Ok(response.items)
+            } else {
+                response
+            }
         }
     }
 
     /// Update a list of resources by converting from a different type, ignoring any that fail
     /// due items missing in CDF.
-    async fn update_from_ignore_unknown_ids<T: 'a, 'a>(
+    fn update_from_ignore_unknown_ids<'a, T: 'a>(
         &self,
         updates: &'a [T],
-    ) -> Result<Vec<TResponse>>
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
     where
-        T: std::marker::Sync + Clone,
+        T: Sync + Clone,
         TUpdate: From<T> + EqIdentity,
         TResponse: Send,
     {
-        let to_update: Vec<TUpdate> = updates.iter().map(|i| TUpdate::from(i.clone())).collect();
-        self.update_ignore_unknown_ids(&to_update).await
+        async move {
+            let to_update: Vec<TUpdate> =
+                updates.iter().map(|i| TUpdate::from(i.clone())).collect();
+            self.update_ignore_unknown_ids(&to_update).await
+        }
     }
 }
 
-#[async_trait]
 /// Trait for retrieving items from CDF by id.
 pub trait Retrieve<TIdt, TResponse>
 where
     TIdt: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Retrieve a list of items from CDF by id.
-    async fn retrieve(&self, ids: &[TIdt]) -> Result<Vec<TResponse>> {
-        let items = Items::from(ids);
-        let response: ItemsWithoutCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/byids", Self::BASE_PATH), &items)
-            .await?;
-        Ok(response.items)
+    fn retrieve(&self, ids: &[TIdt]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let items = Items::from(ids);
+            let response: ItemsWithoutCursor<TResponse> = self
+                .get_client()
+                .post(&format!("{}/byids", Self::BASE_PATH), &items)
+                .await?;
+            Ok(response.items)
+        }
     }
 }
 
-#[async_trait]
 /// Trait for retrieving items from CDF with a more complex request type.
 pub trait RetrieveWithRequest<TRequest, TResponse>
 where
     TRequest: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
-    async fn retrieve(&self, req: &TRequest) -> Result<TResponse> {
-        let response: TResponse = self
-            .get_client()
-            .post(&format!("{}/byids", Self::BASE_PATH), req)
-            .await?;
-        Ok(response)
+    fn retrieve(&self, req: &TRequest) -> impl Future<Output = Result<TResponse>> + Send {
+        async move {
+            let response: TResponse = self
+                .get_client()
+                .post(&format!("{}/byids", Self::BASE_PATH), req)
+                .await?;
+            Ok(response)
+        }
     }
 }
 
-#[async_trait]
 /// Trait for retrieving items from CDF with an option to ignore unknown IDs.
 pub trait RetrieveWithIgnoreUnknownIds<TIdt, TResponse>
 where
     TIdt: Serialize + Sync + Send,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Retrieve a list of items from CDF. If ignore_unknown_ids is false,
     /// this will fail if any items are missing from CDF.
-    async fn retrieve(&self, ids: &[TIdt], ignore_unknown_ids: bool) -> Result<Vec<TResponse>> {
-        let mut items = ItemsWithIgnoreUnknownIds::from(ids);
-        items.ignore_unknown_ids = ignore_unknown_ids;
-        let response: ItemsWithoutCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/byids", Self::BASE_PATH), &items)
-            .await?;
-        Ok(response.items)
+    fn retrieve(
+        &self,
+        ids: &[TIdt],
+        ignore_unknown_ids: bool,
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let mut items = ItemsWithIgnoreUnknownIds::from(ids);
+            items.ignore_unknown_ids = ignore_unknown_ids;
+            let response: ItemsWithoutCursor<TResponse> = self
+                .get_client()
+                .post(&format!("{}/byids", Self::BASE_PATH), &items)
+                .await?;
+            Ok(response.items)
+        }
     }
 }
 
-#[async_trait]
 /// Trait for resource types that allow filtering with a simple filter.
 pub trait FilterItems<TFilter, TResponse>
 where
     TFilter: Serialize + Sync + Send + 'static,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Filter resources using a simple filter.
     /// The response may contain a cursor that can be used to paginate results.
-    async fn filter_items(
+    fn filter_items(
         &self,
         filter: TFilter,
         cursor: Option<String>,
         limit: Option<u32>,
-    ) -> Result<ItemsWithCursor<TResponse>> {
-        let filter = Filter::<TFilter>::new(filter, cursor, limit);
-        let response: ItemsWithCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/list", Self::BASE_PATH), &filter)
-            .await?;
-        Ok(response)
+    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+        async move {
+            let filter = Filter::<TFilter>::new(filter, cursor, limit);
+            let response: ItemsWithCursor<TResponse> = self
+                .get_client()
+                .post(&format!("{}/list", Self::BASE_PATH), &filter)
+                .await?;
+            Ok(response)
+        }
     }
 }
 
@@ -558,41 +612,47 @@ struct CursorStreamState<TFilter, TResponse> {
     next_cursor: CursorState,
 }
 
-#[async_trait]
 /// Trait for resource types that allow filtering with a more complex request.
 pub trait FilterWithRequest<TFilter, TResponse>
 where
     TFilter: Serialize + Sync + Send + 'static,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Filter resources.
-    async fn filter(&self, filter: TFilter) -> Result<ItemsWithCursor<TResponse>> {
-        let response: ItemsWithCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/list", Self::BASE_PATH), &filter)
-            .await?;
-        Ok(response)
-    }
-
-    /// Filter resources, following cursors until they are exhausted.
-    async fn filter_all(&self, mut filter: TFilter) -> Result<Vec<TResponse>>
-    where
-        TFilter: SetCursor,
-        TResponse: Send,
-    {
-        let mut result = vec![];
-        loop {
+    fn filter(
+        &self,
+        filter: TFilter,
+    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+        async move {
             let response: ItemsWithCursor<TResponse> = self
                 .get_client()
                 .post(&format!("{}/list", Self::BASE_PATH), &filter)
                 .await?;
-            for it in response.items {
-                result.push(it);
-            }
-            match response.next_cursor {
-                Some(cursor) => filter.set_cursor(Some(cursor)),
-                None => return Ok(result),
+            Ok(response)
+        }
+    }
+
+    /// Filter resources, following cursors until they are exhausted.
+    fn filter_all(&self, mut filter: TFilter) -> impl Future<Output = Result<Vec<TResponse>>> + Send
+    where
+        TFilter: SetCursor,
+        TResponse: Send,
+    {
+        async move {
+            let mut result = vec![];
+            loop {
+                let response: ItemsWithCursor<TResponse> = self
+                    .get_client()
+                    .post(&format!("{}/list", Self::BASE_PATH), &filter)
+                    .await?;
+                for it in response.items {
+                    result.push(it);
+                }
+                match response.next_cursor {
+                    Some(cursor) => filter.set_cursor(Some(cursor)),
+                    None => return Ok(result),
+                }
             }
         }
     }
@@ -605,7 +665,7 @@ where
     fn filter_all_stream<'a>(
         &'a self,
         filter: TFilter,
-    ) -> Pin<Box<dyn TryStream<Ok = TResponse, Error = crate::Error, Item = Result<TResponse>> + 'a>>
+    ) -> impl TryStream<Ok = TResponse, Error = crate::Error, Item = Result<TResponse>> + Send + 'a
     where
         TFilter: SetCursor,
         TResponse: Send + 'static,
@@ -616,7 +676,7 @@ where
             next_cursor: CursorState::Initial,
         };
 
-        Box::pin(try_unfold(state, move |mut state| async move {
+        try_unfold(state, move |mut state| async move {
             if let Some(next) = state.responses.pop_front() {
                 Ok(Some((next, state)))
             } else {
@@ -644,55 +704,59 @@ where
                     Ok(None)
                 }
             }
-        }))
+        })
     }
 
     /// Filter resources using partitioned reads, following cursors until all partitions are
     /// exhausted.
-    async fn filter_all_partitioned(
+    fn filter_all_partitioned(
         &self,
         filter: TFilter,
         num_partitions: u32,
-    ) -> Result<Vec<TResponse>>
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send
     where
         TFilter: SetCursor + WithPartition,
         TResponse: Send,
     {
-        let mut futures = Vec::with_capacity(num_partitions as usize);
-        for partition in 0..num_partitions {
-            let part_filter = filter.with_partition(Partition::new(partition + 1, num_partitions));
-            futures.push(self.filter_all(part_filter));
+        async move {
+            let mut futures = Vec::with_capacity(num_partitions as usize);
+            for partition in 0..num_partitions {
+                let part_filter =
+                    filter.with_partition(Partition::new(partition + 1, num_partitions));
+                futures.push(self.filter_all(part_filter));
+            }
+            let results = try_join_all(futures).await?;
+            let mut response_items = Vec::with_capacity(results.iter().map(|i| i.len()).sum());
+            for chunk in results.into_iter() {
+                response_items.extend(chunk);
+            }
+            Ok(response_items)
         }
-        let results = try_join_all(futures).await?;
-        let mut response_items = Vec::with_capacity(results.iter().map(|i| i.len()).sum());
-        for chunk in results.into_iter() {
-            response_items.extend(chunk);
-        }
-        Ok(response_items)
     }
 }
 
-#[async_trait]
 /// Trait for resource types that allow filtering with fuzzy search.
-pub trait SearchItems<TFilter, TSearch, TResponse, 'a>
+pub trait SearchItems<'a, TFilter, TSearch, TResponse>
 where
     TFilter: Serialize + Sync + Send + 'a,
     TSearch: Serialize + Sync + Send + 'a,
     TResponse: Serialize + DeserializeOwned,
-    Self: WithApiClient + WithBasePath,
+    Self: WithApiClient + WithBasePath + Sync,
 {
     /// Fuzzy search resources.
-    async fn search(
+    fn search(
         &'a self,
         filter: TFilter,
         search: TSearch,
         limit: Option<u32>,
-    ) -> Result<Vec<TResponse>> {
-        let req = Search::<TFilter, TSearch>::new(filter, search, limit);
-        let response: ItemsWithoutCursor<TResponse> = self
-            .get_client()
-            .post(&format!("{}/search", Self::BASE_PATH), &req)
-            .await?;
-        Ok(response.items)
+    ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
+        async move {
+            let req = Search::<TFilter, TSearch>::new(filter, search, limit);
+            let response: ItemsWithoutCursor<TResponse> = self
+                .get_client()
+                .post(&format!("{}/search", Self::BASE_PATH), &req)
+                .await?;
+            Ok(response.items)
+        }
     }
 }


### PR DESCRIPTION
A few caveats to this:

 - MSRV would be 1.75
 - Resources are no longer dyn-safe. This is less of a concern since it doesn't make a lot of sense to have a dynamic reference to some CDF resource, but it might be problematic. They might be in the future.
 - Trait definitions are a little more fiddly, since we need send bounds on the returned futures.
 - We still need async-trait for the auth traits and for middleware, since those require object-safe traits still.

This is a small reduction in overhead, since impl trait is zero-cost, unlike the async-trait macro, it also makes IDEs agree with the code a bit more, which is nice.