### PR TITLE
Improve authenticator ergonomics

### DIFF
--- a/cognite/src/api/api_client.rs
+++ b/cognite/src/api/api_client.rs
@@ -60,7 +60,7 @@ impl ApiClient {
         }
     }
 
-    async fn send_request<T: DeserializeOwned>(
+    async fn send_request_json<T: DeserializeOwned>(
         &self,
         mut request_builder: RequestBuilder,
     ) -> Result<T> {
@@ -117,7 +117,7 @@ impl ApiClient {
         let url = format!("{}/{}", self.api_base_url, path);
         let headers: HeaderMap = self.get_headers();
         let request_builder = self.client.get(&url).headers(headers);
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a get request to the given path, with a query given by `params`,
@@ -135,7 +135,7 @@ impl ApiClient {
         let url = format!("{}/{}", self.api_base_url, path);
         let headers: HeaderMap = self.get_headers();
         let request_builder = self.client.get(&url).headers(headers).query(&http_params);
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a get request to the given URL, returning a stream.
@@ -182,7 +182,7 @@ impl ApiClient {
         let url = format!("{}/{}", self.api_base_url, path);
         let headers: HeaderMap = self.get_headers();
         let request_builder = self.client.post(&url).headers(headers).body(body);
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a post request to the given path, with query parameters given by `params`.
@@ -209,7 +209,7 @@ impl ApiClient {
             .headers(headers)
             .query(&http_params)
             .body(json);
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a post request to the given path, posting `value` as protobuf.
@@ -230,7 +230,7 @@ impl ApiClient {
             .post(&url)
             .headers(headers)
             .body(value.encode_to_vec());
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a post request to the given path, send `object` as JSON in the body,
@@ -340,7 +340,7 @@ impl ApiClient {
             .put(&url)
             .headers(headers)
             .body(String::from(body));
-        self.send_request(request_builder).await
+        self.send_request_json(request_builder).await
     }
 
     /// Perform a delete request to `path`, expecting JSON as response.
@@ -348,7 +348,7 @@ impl ApiClient {
         let url = format!("{}/{}", self.api_base_url, path);
         let headers: HeaderMap = self.get_headers();
         let request_builder = self.client.delete(&url).headers(headers);
-        self.send_request::<T>(request_builder).await
+        self.send_request_json::<T>(request_builder).await
     }
 
     /// Perform a delete request to `path`, with query parameters given by `params`.
@@ -369,6 +369,19 @@ impl ApiClient {
             .delete(&url)
             .headers(headers)
             .query(&http_params);
-        self.send_request::<T>(request_builder).await
+        self.send_request_json::<T>(request_builder).await
+    }
+
+    /// Send an arbitrary HTTP request using the client. This will not parse the response,
+    /// but will append authentication headers and retry with the same semantics as any
+    /// normal API call.
+    ///
+    /// # Arguments
+    ///
+    /// * `request_builder` - Request to send.
+    pub async fn send_request(&self, mut request_builder: RequestBuilder) -> Result<Response> {
+        request_builder.extensions().insert(self.client.clone());
+
+        Ok(request_builder.send().await?)
     }
 }

--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -227,7 +227,7 @@ impl Authenticator {
             return match serde_json::from_str(&response) {
                 Ok(e) => Err(e),
                 Err(e) => Err(AuthenticatorError::internal_error(
-                    format!("Something went wrong (status: {status}), but the response error couldn't be deserialized. Raw response: {e}")
+                    format!("Something went wrong (status: {status}), but the response error couldn't be deserialized. Raw response: {response}")
                     , Some(e.to_string())))
             };
         }

--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use futures_locks::RwLock;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
-    StatusCode,
+    Method, StatusCode,
 };
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
@@ -100,6 +100,8 @@ pub struct AuthenticatorConfig {
     pub audience: Option<String>,
     /// Optional space separate list of scopes.
     pub scopes: Option<String>,
+    /// HTTP method to use, defaults to GET.
+    pub http_method: Option<reqwest::Method>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -183,6 +185,7 @@ pub struct Authenticator {
     req: AuthenticatorRequest,
     state: RwLock<AuthenticatorState>,
     token_url: String,
+    method: Method,
 }
 
 impl Authenticator {
@@ -190,6 +193,7 @@ impl Authenticator {
     pub fn new(config: AuthenticatorConfig) -> Authenticator {
         Authenticator {
             token_url: config.token_url.clone(),
+            method: config.http_method.clone().unwrap_or(Method::GET),
             req: AuthenticatorRequest::new(config),
             state: RwLock::new(AuthenticatorState {
                 last_response: None,
@@ -203,7 +207,7 @@ impl Authenticator {
         client: &ClientWithMiddleware,
     ) -> Result<AuthenticatorResponse, AuthenticatorError> {
         let response = client
-            .get(&self.token_url)
+            .request(self.method.clone(), &self.token_url)
             .form(&self.req)
             .send()
             .await

--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -216,18 +216,23 @@ impl Authenticator {
 
         let status = response.status();
 
+        let response = response.text().await.map_err(|e| {
+            AuthenticatorError::internal_error(
+                "Failed to receive response contents".to_owned(),
+                Some(e.to_string()),
+            )
+        })?;
+
         if status != StatusCode::OK {
-            return Err(
-                response.json::<AuthenticatorError>().await.map_err(|e| {
-                    AuthenticatorError::internal_error(
-                         format!("Something went wrong (status: {status}), but the response error couldn't be deserialized"),
-                        Some(e.to_string()),
-                    )
-                })?,
-            );
+            return match serde_json::from_str(&response) {
+                Ok(e) => Err(e),
+                Err(e) => Err(AuthenticatorError::internal_error(
+                    format!("Something went wrong (status: {status}), but the response error couldn't be deserialized. Raw response: {e}")
+                    , Some(e.to_string())))
+            };
         }
 
-        response.json::<AuthenticatorResponse>().await.map_err(|e| {
+        serde_json::from_str(&response).map_err(|e| {
             AuthenticatorError::internal_error(
                 "Failed to deserialize".to_string(),
                 Some(e.to_string()),

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -77,8 +77,6 @@ pub struct CogniteClient {
     pub sequences: SequencesResource,
     pub sessions: SessionsResource,
     pub models: Models,
-
-    pub http_client: ClientWithMiddleware,
 }
 
 static COGNITE_BASE_URL: &str = "COGNITE_BASE_URL";
@@ -117,7 +115,7 @@ impl CogniteClient {
         let client = Self::get_client(config.unwrap_or_default(), auth, None, None)?;
         let api_client = ApiClient::new(&api_base_path, app_name, client.clone());
 
-        Self::new_internal(api_client, client)
+        Self::new_internal(api_client)
     }
 
     fn get_client(
@@ -166,10 +164,10 @@ impl CogniteClient {
         let api_base_path = format!("{}/api/{}/projects/{}", base_url, "v1", project);
         let client = Self::get_client(config, auth, client, middleware)?;
         let api_client = ApiClient::new(&api_base_path, &app_name, client.clone());
-        Self::new_internal(api_client, client)
+        Self::new_internal(api_client)
     }
 
-    fn new_internal(api_client: ApiClient, http_client: ClientWithMiddleware) -> Result<Self> {
+    fn new_internal(api_client: ApiClient) -> Result<Self> {
         let ac = Arc::new(api_client);
         Ok(CogniteClient {
             api_client: ac.clone(),
@@ -188,7 +186,6 @@ impl CogniteClient {
             sequences: SequencesResource::new(ac.clone()),
             sessions: SessionsResource::new(ac.clone()),
             models: Models::new(ac),
-            http_client,
         })
     }
 
@@ -205,7 +202,7 @@ impl CogniteClient {
         let client = Self::get_client(config.unwrap_or_default(), auth, None, None)?;
         let api_client = ApiClient::new(&api_base_path, app_name, client.clone());
 
-        Self::new_internal(api_client, client)
+        Self::new_internal(api_client)
     }
 
     pub fn builder() -> Builder {

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -99,7 +99,6 @@ impl CogniteClient {
             resource: env_or_none!(COGNITE_RESOURCE),
             audience: env_or_none!(COGNITE_AUDIENCE),
             scopes: env_or_none!(COGNITE_SCOPES),
-            http_method: None,
         };
 
         CogniteClient::new_from_oidc(&api_base_url, auth_config, &project_name, app_name, config)

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -99,6 +99,7 @@ impl CogniteClient {
             resource: env_or_none!(COGNITE_RESOURCE),
             audience: env_or_none!(COGNITE_AUDIENCE),
             scopes: env_or_none!(COGNITE_SCOPES),
+            http_method: None,
         };
 
         CogniteClient::new_from_oidc(&api_base_url, auth_config, &project_name, app_name, config)


### PR DESCRIPTION
 - Make the request method POST. It's what we use elsewhere, and it seems to be more generally accepted.
 - Log the raw error message if it fails to deserialize.
 - Expose the HTTP client we use, to make it easier to reuse the authentication.