### PR TITLE
Make errors less messy

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.105"
 task-local-extensions = "0.1.4"
 thiserror = "1.0.56"
 wiremock = "0.5.22"
+anyhow = "1.0.79"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.35.1", features = ["macros", "rt-multi-thread"] }

--- a/cognite/src/api/utils.rs
+++ b/cognite/src/api/utils.rs
@@ -1,4 +1,4 @@
-use crate::{Identity, Kind, Result};
+use crate::{Error, Identity, Result};
 
 /// Given a result object from CDF, if it is a "conflict" error,
 /// return the list of identities.
@@ -9,8 +9,8 @@ use crate::{Identity, Kind, Result};
 pub fn get_duplicates_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
     match res {
         Ok(_) => None,
-        Err(e) => match &e.kind {
-            Kind::Conflict(c) => c
+        Err(e) => match &e {
+            Error::Conflict(c) => c
                 .duplicated
                 .as_ref()
                 .map(|dup| dup.get_identities().collect()),
@@ -28,9 +28,9 @@ pub fn get_duplicates_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
 pub fn get_missing_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
     match res {
         Ok(_) => None,
-        Err(e) => match &e.kind {
-            Kind::BadRequest(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
-            Kind::NotFound(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
+        Err(e) => match &e {
+            Error::BadRequest(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
+            Error::NotFound(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
             _ => None,
         },
     }

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -10,7 +10,6 @@ use crate::api::data_modeling::Models;
 use crate::api::iam::groups::GroupsResource;
 use crate::api::iam::sessions::SessionsResource;
 use crate::auth::AuthenticatorMiddleware;
-use crate::error::Kind;
 use crate::retry::CustomRetryMiddleware;
 use crate::AuthHeaderManager;
 use crate::{
@@ -29,7 +28,7 @@ macro_rules! env_or_error {
             Err(err) => {
                 let error_message =
                     format!("{} is not defined in the environment. Error: {}", $e, err);
-                return Err(Error::new(Kind::EnvironmentVariableMissing(error_message)));
+                return Err(Error::EnvironmentVariableMissing(error_message));
             }
         }
     };
@@ -375,15 +374,15 @@ impl Builder {
     pub fn build(self) -> Result<CogniteClient> {
         let auth = self
             .auth
-            .ok_or_else(|| Error::new(Kind::Config("Some form of auth is required".to_string())))?;
+            .ok_or_else(|| Error::Config("Some form of auth is required".to_string()))?;
         let config = self.config.unwrap_or_default();
         let client = self.client;
         let app_name = self
             .app_name
-            .ok_or_else(|| Error::new(Kind::Config("App name is required".to_string())))?;
+            .ok_or_else(|| Error::Config("App name is required".to_string()))?;
         let project = self
             .project
-            .ok_or_else(|| Error::new(Kind::Config("Project is required".to_string())))?;
+            .ok_or_else(|| Error::Config("Project is required".to_string()))?;
         let base_url = self
             .base_url
             .unwrap_or_else(|| "https://api.cognitedata.com/".to_owned());

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -19,10 +19,8 @@ async fn ensure_test_file(client: &CogniteClient) {
     };
 
     let file = match client.files.upload(false, &new_file).await {
-        Err(cognite::Error { kind }) => match kind {
-            cognite::Kind::Conflict(_) => return,
-            e => panic!("{}", e),
-        },
+        Err(cognite::Error::Conflict(_)) => return,
+        Err(e) => panic!("{}", e),
         Ok(f) => f,
     };
 


### PR DESCRIPTION
Errors were doing a lot they didn't need to. This makes them more consistent, and also prefers anyhow::Error over String in a few cases where it is possible to capture more error context.