### PR TITLE
Add a few missing default impls

### DIFF
--- a/cognite/src/dto/data_modeling/common.rs
+++ b/cognite/src/dto/data_modeling/common.rs
@@ -73,10 +73,11 @@ impl From<ItemId> for TaggedContainerReference {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Enum for whether a resource is used for nodes, edges, or both.
 pub enum UsedFor {
+    #[default]
     /// Used for nodes.
     Node,
     /// Used for edges.

--- a/cognite/src/dto/data_modeling/containers.rs
+++ b/cognite/src/dto/data_modeling/containers.rs
@@ -43,7 +43,7 @@ pub enum ContainerPropertyType {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Constraints for a property that is a reference to a node.
 pub struct DirectNodeRelationType {
@@ -110,7 +110,7 @@ pub struct ContainerPropertyDefinition {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Create a container.
 pub struct ContainerCreate {
@@ -133,7 +133,7 @@ pub struct ContainerCreate {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Data modeling container.
 pub struct ContainerDefinition {
@@ -177,7 +177,7 @@ impl From<ContainerDefinition> for ContainerCreate {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// ID of a container index or constraint.
 pub struct ContainerComponentId {

--- a/cognite/src/dto/data_modeling/data_models.rs
+++ b/cognite/src/dto/data_modeling/data_models.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Create a data model.
 pub struct DataModelCreate {
@@ -41,7 +41,7 @@ impl From<DataModel> for DataModelCreate {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// A CDF data model.
 pub struct DataModel {
@@ -66,7 +66,7 @@ pub struct DataModel {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// ID of a data model
 pub struct DataModelId {

--- a/cognite/src/dto/data_modeling/spaces.rs
+++ b/cognite/src/dto/data_modeling/spaces.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Object used to create a space.
 pub struct SpaceCreate {
@@ -17,7 +17,7 @@ pub struct SpaceCreate {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Description of a data modeling space.
 pub struct Space {

--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -17,7 +17,7 @@ use super::{
     query::{QueryDirection, ViewPropertyReference},
 };
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Reference to a view.
 pub struct ViewReference {
@@ -98,7 +98,7 @@ pub enum ViewDefinitionOrReference {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Create a new view.
 pub struct ViewCreateDefinition {
@@ -249,7 +249,7 @@ pub enum ConnectionDefinition {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 /// Definition of a view.
 pub struct ViewDefinition {


### PR DESCRIPTION
The FDW uses default impls on create in particular a lot, and these are handy to have in places where they make sense, in particular as they allow the 

```
struct SomeStruct {
    foo: 123,
    ..Default::default()
}
```

syntax.