### PR TITLE
Remove openssl feature from reqwest

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -18,7 +18,13 @@ futures-locks = "0.7.1"
 futures-timer = "3.0.2"
 prost = "0.12.3"
 prost-types = "0.12.3"
-reqwest = { version = "0.11.23", features = ["json", "stream"] }
+reqwest = { version = "0.11.23", features = [
+    "gzip",
+    "json",
+    "multipart",
+    "rustls-tls-native-roots",
+    "stream",
+], default-features = false } # Default brings in openssl
 reqwest-middleware = "0.2.4"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_with = "3.4.0"


### PR DESCRIPTION
Don't bring in openssl feature with reqwest crate.

Bringing in openssl forces us to link against it in the monorepo, which we would prefer to avoid.