### PR TITLE
Split out README for users (to cognite/) and devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Cognite Rust SDK
 
-==========================
-
 Rust SDK to ensure excellent user experience for developers and data scientists working with the Cognite Data Fusion.
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Rust SDK to ensure excellent user experience for developers and data scientists 
 
 Do you want to use the Cognite SDK in your project? Check out [these docs](cognite/README.md) and [API documentation](https://docs.cognite.com/api/v1/).
 
-## Do you want to contibute?
+## Do you want to contibute to the SDK?
 
 See [Contributing](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -1,120 +1,15 @@
-Cognite Rust SDK
+# Cognite Rust SDK
+
 ==========================
 
 Rust SDK to ensure excellent user experience for developers and data scientists working with the Cognite Data Fusion.
 
-## Documentation
-* [API Documentation](https://docs.cognite.com/api/v1/)
+---
 
-## Prerequisites
-Install rust. See [instructions here](https://rustup.rs/).
+## Using the Cognite SDK
 
-To build the SDK, you will also need a version of protobuf-compiler, on debian based systems that can be installed using `sudo apt-get install protobuf-compiler`.
+Do you want to use the Cognite SDK in your project? Check out [these docs](cognite/README.md) and [API documentation](https://docs.cognite.com/api/v1/).
 
-Set environment variables:
-
-```bash
-$ export COGNITE_BASE_URL="https://api.cognitedata.com"
-$ export COGNITE_CLIENT_ID=<your client id>
-$ export COGNITE_CLIENT_SECRET=<your client secret>
-$ export COGNITE_TOKEN_URL=<your token url>
-$ export COGNITE_SCOPES=<space separated list of scopes>
-$ export COGNITE_PROJECT=<your project name>
-```
-
-## Supported features for API v1
-
-### Core
-- Assets
-- Events
-- Files
-- TimeSeries
-  - With protobuf support
-- Sequences
-### IAM
-- Groups
-- SecurityCategories
-- Sessions
-### Data Ingestion
-- Extraction pipelines
-- Raw
-### Data Organization
-- Datasets
-- Labels
-- Relationships
-### Data Modeling
-- Instances 
-- Spaces
-- Views
-
-## Example
-
-Since this is not published on crates.io, you'll have to reference the git repository
-
-Cargo.toml:
-
-```TOML
-[dependencies]
-cognite = { git = "https://github.com/cognitedata/cognite-sdk-rust" }
-tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }
-```
-
-```Rust
-use cognite::prelude::*;
-use cognite::{Asset, AssetFilter, AssetSearch, CogniteClient};
-
-#[tokio::main]
-fn main() {
-    // Create a client from environment variables
-    let cognite_client = CogniteClient::new("TestApp", None).unwrap();
-
-    // List all assets
-    let mut filter: AssetFilter = AssetFilter::new();
-    filter.name = Some("Aker".to_string());
-    let assets = cognite_client
-        .assets
-        .filter(FilterAssetsRequest {
-            filter,
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-
-    // Retrieve asset
-    match cognite_client
-        .assets
-        .retrieve(&vec![Identity::from(6687602007296940)], false, None)
-        .await
-        .unwrap();
-}
-```
-
-Using the builder pattern to set OIDC credentials:
-
-```Rust
-use cognite::prelude::*;
-
-#[tokio::main]
-fn main() {
-    let builder = CogniteClient::builder();
-    builder
-        .set_oidc_credentials(AuthenticatorConfig {
-            ...
-        })
-        .set_project("my_project")
-        .set_app_name("TestApp")
-        .set_base_url("https://api.cognitedata.com");
-    let cognite_client = builder.build().unwrap();
-}
-
-```
-
-## Run examples
-
-```bash
-cargo run --example client
-```
-
-## Contributing
+## Do you want to contibute?
 
 See [Contributing](CONTRIBUTING.md) for details.

--- a/cognite/README.md
+++ b/cognite/README.md
@@ -1,7 +1,5 @@
 # Cognite Rust SDK
 
-==========================
-
 Rust SDK to ensure excellent user experience for developers and data scientists working with the Cognite Data Fusion.
 
 ## Documentation

--- a/cognite/README.md
+++ b/cognite/README.md
@@ -1,0 +1,120 @@
+Cognite Rust SDK
+==========================
+
+Rust SDK to ensure excellent user experience for developers and data scientists working with the Cognite Data Fusion.
+
+## Documentation
+* [API Documentation](https://docs.cognite.com/api/v1/)
+
+## Prerequisites
+Install rust. See [instructions here](https://rustup.rs/).
+
+To build the SDK, you will also need a version of protobuf-compiler, on debian based systems that can be installed using `sudo apt-get install protobuf-compiler`.
+
+Set environment variables:
+
+```bash
+$ export COGNITE_BASE_URL="https://api.cognitedata.com"
+$ export COGNITE_CLIENT_ID=<your client id>
+$ export COGNITE_CLIENT_SECRET=<your client secret>
+$ export COGNITE_TOKEN_URL=<your token url>
+$ export COGNITE_SCOPES=<space separated list of scopes>
+$ export COGNITE_PROJECT=<your project name>
+```
+
+## Supported features for API v1
+
+### Core
+- Assets
+- Events
+- Files
+- TimeSeries
+  - With protobuf support
+- Sequences
+### IAM
+- Groups
+- SecurityCategories
+- Sessions
+### Data Ingestion
+- Extraction pipelines
+- Raw
+### Data Organization
+- Datasets
+- Labels
+- Relationships
+### Data Modeling
+- Instances 
+- Spaces
+- Views
+
+## Example
+
+Since this is not published on crates.io, you'll have to reference the git repository
+
+Cargo.toml:
+
+```TOML
+[dependencies]
+cognite = { git = "https://github.com/cognitedata/cognite-sdk-rust" }
+tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }
+```
+
+```Rust
+use cognite::prelude::*;
+use cognite::{Asset, AssetFilter, AssetSearch, CogniteClient};
+
+#[tokio::main]
+fn main() {
+    // Create a client from environment variables
+    let cognite_client = CogniteClient::new("TestApp", None).unwrap();
+
+    // List all assets
+    let mut filter: AssetFilter = AssetFilter::new();
+    filter.name = Some("Aker".to_string());
+    let assets = cognite_client
+        .assets
+        .filter(FilterAssetsRequest {
+            filter,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    // Retrieve asset
+    match cognite_client
+        .assets
+        .retrieve(&vec![Identity::from(6687602007296940)], false, None)
+        .await
+        .unwrap();
+}
+```
+
+Using the builder pattern to set OIDC credentials:
+
+```Rust
+use cognite::prelude::*;
+
+#[tokio::main]
+fn main() {
+    let builder = CogniteClient::builder();
+    builder
+        .set_oidc_credentials(AuthenticatorConfig {
+            ...
+        })
+        .set_project("my_project")
+        .set_app_name("TestApp")
+        .set_base_url("https://api.cognitedata.com");
+    let cognite_client = builder.build().unwrap();
+}
+
+```
+
+## Run examples
+
+```bash
+cargo run --example client
+```
+
+## Contributing
+
+See [Contributing](CONTRIBUTING.md) for details.

--- a/cognite/README.md
+++ b/cognite/README.md
@@ -1,12 +1,15 @@
-Cognite Rust SDK
+# Cognite Rust SDK
+
 ==========================
 
 Rust SDK to ensure excellent user experience for developers and data scientists working with the Cognite Data Fusion.
 
 ## Documentation
+
 * [API Documentation](https://docs.cognite.com/api/v1/)
 
 ## Prerequisites
+
 Install rust. See [instructions here](https://rustup.rs/).
 
 To build the SDK, you will also need a version of protobuf-compiler, on debian based systems that can be installed using `sudo apt-get install protobuf-compiler`.
@@ -14,38 +17,47 @@ To build the SDK, you will also need a version of protobuf-compiler, on debian b
 Set environment variables:
 
 ```bash
-$ export COGNITE_BASE_URL="https://api.cognitedata.com"
-$ export COGNITE_CLIENT_ID=<your client id>
-$ export COGNITE_CLIENT_SECRET=<your client secret>
-$ export COGNITE_TOKEN_URL=<your token url>
-$ export COGNITE_SCOPES=<space separated list of scopes>
-$ export COGNITE_PROJECT=<your project name>
+export COGNITE_BASE_URL="https://api.cognitedata.com"
+export COGNITE_CLIENT_ID=<your client id>
+export COGNITE_CLIENT_SECRET=<your client secret>
+export COGNITE_TOKEN_URL=<your token url>
+export COGNITE_SCOPES=<space separated list of scopes>
+export COGNITE_PROJECT=<your project name>
 ```
 
 ## Supported features for API v1
 
 ### Core
-- Assets
-- Events
-- Files
-- TimeSeries
-  - With protobuf support
-- Sequences
+
+* Assets
+* Events
+* Files
+* TimeSeries
+  * With protobuf support
+* Sequences
+
 ### IAM
-- Groups
-- SecurityCategories
-- Sessions
+
+* Groups
+* SecurityCategories
+* Sessions
+
 ### Data Ingestion
-- Extraction pipelines
-- Raw
+
+* Extraction pipelines
+* Raw
+
 ### Data Organization
-- Datasets
-- Labels
-- Relationships
+
+* Datasets
+* Labels
+* Relationships
+
 ### Data Modeling
-- Instances 
-- Spaces
-- Views
+
+* Instances
+* Spaces
+* Views
 
 ## Example
 

--- a/cognite/src/lib.rs
+++ b/cognite/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 mod cognite_client;
 
 mod api;


### PR DESCRIPTION
The `cognite` crate should be self-contained, but it was referring to the README.md in the workspace. 

The README should be in the crate itself. Split up the README into a user-facing README in `cognite`, and a more developer oriented README in the workspace.

Context for this change: https://cognitedata.slack.com/archives/C03U0JKUEQZ/p1706597740067559?thread_ts=1706519213.544409&cid=C03U0JKUEQZ