### PR TITLE
Ignore duplicates when creating missing time series

### DIFF
--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -107,7 +107,7 @@ impl TimeSeriesResource {
         let futures = to_create
             .chunks(1000)
             // Since we're discarding the output, don't collect it here.
-            .map(|c| self.create(c).map(|r| r.map(|_| ())));
+            .map(|c| self.create_ignore_duplicates(c).map(|r| r.map(|_| ())));
 
         execute_with_parallelism(futures, 4).await?;
 


### PR DESCRIPTION
Helps improve resiliency when making multiple requests in parallel.