### PR TITLE
Unify into a single Items type

### DIFF
--- a/cognite/src/api/core/assets.rs
+++ b/cognite/src/api/core/assets.rs
@@ -1,7 +1,7 @@
 use crate::api::resource::*;
 use crate::dto::core::asset::*;
 use crate::error::Result;
-use crate::{Identity, ItemsWithoutCursor, Patch};
+use crate::{Identity, ItemsVec, Patch};
 
 /// Assets represent objects or groups of objects from the physical world.
 /// Assets are organized in hierarchies. For example, a water pump asset can
@@ -40,7 +40,7 @@ impl AssetsResource {
         let mut id_items = RetrieveAssetsRequest::from(asset_ids);
         id_items.ignore_unknown_ids = ignore_unknown_ids;
         id_items.aggregated_properties = aggregated_properties;
-        let assets_response: ItemsWithoutCursor<Asset> =
+        let assets_response: ItemsVec<Asset> =
             self.api_client.post("assets/byids", &id_items).await?;
         Ok(assets_response.items)
     }
@@ -57,7 +57,7 @@ impl AssetsResource {
         &self,
         aggregate: AssetAggregateRequest,
     ) -> Result<Vec<AssetAggregateResponse>> {
-        let resp: ItemsWithoutCursor<AssetAggregateResponse> =
+        let resp: ItemsVec<AssetAggregateResponse> =
             self.api_client.post("assets/aggregate", &aggregate).await?;
         Ok(resp.items)
     }

--- a/cognite/src/api/core/events.rs
+++ b/cognite/src/api/core/events.rs
@@ -1,7 +1,7 @@
 use crate::api::resource::*;
 use crate::dto::core::event::*;
 use crate::error::Result;
-use crate::{Identity, ItemsWithoutCursor, Patch};
+use crate::{Identity, ItemsVec, Patch};
 
 /// Event objects store complex information about multiple assets over a time period.
 /// Typical types of events might include Alarms, Process Data, and Logs.
@@ -37,7 +37,7 @@ impl EventsResource {
         &self,
         aggregate: EventAggregateRequest,
     ) -> Result<Vec<EventAggregateResponse>> {
-        let resp: ItemsWithoutCursor<EventAggregateResponse> =
+        let resp: ItemsVec<EventAggregateResponse> =
             self.api_client.post("events/aggregate", &aggregate).await?;
         Ok(resp.items)
     }

--- a/cognite/src/api/core/files.rs
+++ b/cognite/src/api/core/files.rs
@@ -5,7 +5,7 @@ use crate::dto::core::files::*;
 use crate::dto::items::Items;
 use crate::error::Result;
 use crate::PartitionedFilter;
-use crate::{Identity, ItemsWithoutCursor, Patch};
+use crate::{Identity, ItemsVec, Patch};
 
 /// Files store documents, binary blobs, and other file data and relate it to assets.
 pub type Files = Resource<FileMetadata>;
@@ -136,8 +136,8 @@ impl Files {
     ///
     /// * `ids` - List of file IDs or external IDs.
     pub async fn download_link(&self, ids: &[Identity]) -> Result<Vec<FileDownloadUrl>> {
-        let items = Items::from(ids);
-        let file_links_response: ItemsWithoutCursor<FileDownloadUrl> =
+        let items = Items::new(ids);
+        let file_links_response: ItemsVec<FileDownloadUrl> =
             self.api_client.post("files/downloadlink", &items).await?;
         Ok(file_links_response.items)
     }

--- a/cognite/src/api/core/sequences.rs
+++ b/cognite/src/api/core/sequences.rs
@@ -27,7 +27,7 @@ impl SequencesResource {
     ///
     /// * `rows` - Sequence row batches to insert.
     pub async fn insert_rows(&self, rows: &[InsertSequenceRows]) -> Result<()> {
-        let items = Items::from(rows);
+        let items = Items::new(rows);
         self.api_client
             .post(&format!("{}/{}", Self::BASE_PATH, "data"), &items)
             .await?;
@@ -69,7 +69,7 @@ impl SequencesResource {
     ///
     /// * `query` - Row ranges to delete.
     pub async fn delete_rows(&self, query: &[DeleteSequenceRows]) -> Result<()> {
-        let items = Items::from(query);
+        let items = Items::new(query);
         self.api_client
             .post(&format!("{}/{}", Self::BASE_PATH, "data/delete"), &items)
             .await

--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -245,7 +245,7 @@ impl TimeSeriesResource {
         items: &[LatestDatapointsQuery],
         ignore_unknown_ids: bool,
     ) -> Result<Vec<DatapointsResponse>> {
-        let query = Items::new_with_extra(items, IgnoreUnknownIds { ignore_unknown_ids });
+        let query = Items::new_with_extra_fields(items, IgnoreUnknownIds { ignore_unknown_ids });
         let datapoints_response: DatapointsListResponse = self
             .api_client
             .post("timeseries/data/latest", &query)

--- a/cognite/src/api/data_modeling/containers.rs
+++ b/cognite/src/api/data_modeling/containers.rs
@@ -3,8 +3,7 @@ use crate::{
         ContainerComponentId, ContainerCreate, ContainerDefinition, ContainerQuery,
     },
     models::ItemId,
-    Create, DeleteWithResponse, Items, ItemsWithoutCursor, List, Resource, Result, Retrieve,
-    WithBasePath,
+    Create, DeleteWithResponse, Items, ItemsVec, List, Resource, Result, Retrieve, WithBasePath,
 };
 
 /// A container represents a bag of properties, each property has a type.
@@ -30,11 +29,11 @@ impl ContainersResource {
         &self,
         items: &[ContainerComponentId],
     ) -> Result<Vec<ContainerComponentId>> {
-        let r: ItemsWithoutCursor<ContainerComponentId> = self
+        let r: ItemsVec<ContainerComponentId> = self
             .api_client
             .post(
                 &format!("{}/constraints/delete", Self::BASE_PATH),
-                &Items::from(items),
+                &Items::new(items),
             )
             .await?;
         Ok(r.items)
@@ -49,11 +48,11 @@ impl ContainersResource {
         &self,
         items: &[ContainerComponentId],
     ) -> Result<Vec<ContainerComponentId>> {
-        let r: ItemsWithoutCursor<ContainerComponentId> = self
+        let r: ItemsVec<ContainerComponentId> = self
             .api_client
             .post(
                 &format!("{}/indexes/delete", Self::BASE_PATH),
-                &Items::from(items),
+                &Items::new(items),
             )
             .await?;
         Ok(r.items)

--- a/cognite/src/api/data_organization/datasets.rs
+++ b/cognite/src/api/data_organization/datasets.rs
@@ -1,5 +1,5 @@
 use crate::api::resource::*;
-use crate::dto::{data_organization::datasets::*, items::ItemsWithCursor};
+use crate::dto::{data_organization::datasets::*, items::ItemsVec};
 use crate::error::Result;
 use crate::{Filter, Identity, Patch};
 
@@ -23,7 +23,7 @@ impl DataSetsResource {
     /// * `filter` - Optional filter.
     pub async fn count(&self, filter: DataSetFilter) -> Result<DataSetsCount> {
         let query = Filter::<DataSetFilter>::new(filter, None, None);
-        let result: ItemsWithCursor<DataSetsCount> =
+        let result: ItemsVec<DataSetsCount> =
             self.api_client.post("datasets/aggregate", &query).await?;
         Ok(result.items.into_iter().next().unwrap())
     }

--- a/cognite/src/api/data_organization/datasets.rs
+++ b/cognite/src/api/data_organization/datasets.rs
@@ -1,5 +1,8 @@
 use crate::api::resource::*;
-use crate::dto::{data_organization::datasets::*, items::ItemsVec};
+use crate::dto::{
+    data_organization::datasets::*,
+    items::{Cursor, ItemsVec},
+};
 use crate::error::Result;
 use crate::{Filter, Identity, Patch};
 
@@ -23,7 +26,7 @@ impl DataSetsResource {
     /// * `filter` - Optional filter.
     pub async fn count(&self, filter: DataSetFilter) -> Result<DataSetsCount> {
         let query = Filter::<DataSetFilter>::new(filter, None, None);
-        let result: ItemsVec<DataSetsCount> =
+        let result: ItemsVec<DataSetsCount, Cursor> =
             self.api_client.post("datasets/aggregate", &query).await?;
         Ok(result.items.into_iter().next().unwrap())
     }

--- a/cognite/src/api/data_organization/relationships.rs
+++ b/cognite/src/api/data_organization/relationships.rs
@@ -1,5 +1,5 @@
 use crate::api::resource::*;
-use crate::dto::{data_organization::relationships::*, items::ItemsWithCursor};
+use crate::dto::{data_organization::relationships::*, items::ItemsVec};
 use crate::error::Result;
 use crate::{CogniteExternalId, Patch};
 
@@ -34,7 +34,7 @@ impl RelationshipsResource {
         let mut id_items = RetrieveRelationshipsRequest::from(relationship_ids);
         id_items.fetch_resources = fetch_resources;
         id_items.ignore_unknown_ids = ignore_unknown_ids;
-        let rel_response: ItemsWithCursor<Relationship> = self
+        let rel_response: ItemsVec<Relationship> = self
             .api_client
             .post("relationships/byids", &id_items)
             .await?;

--- a/cognite/src/api/data_organization/relationships.rs
+++ b/cognite/src/api/data_organization/relationships.rs
@@ -1,5 +1,8 @@
 use crate::api::resource::*;
-use crate::dto::{data_organization::relationships::*, items::ItemsVec};
+use crate::dto::{
+    data_organization::relationships::*,
+    items::{Cursor, ItemsVec},
+};
 use crate::error::Result;
 use crate::{CogniteExternalId, Patch};
 
@@ -34,7 +37,7 @@ impl RelationshipsResource {
         let mut id_items = RetrieveRelationshipsRequest::from(relationship_ids);
         id_items.fetch_resources = fetch_resources;
         id_items.ignore_unknown_ids = ignore_unknown_ids;
-        let rel_response: ItemsVec<Relationship> = self
+        let rel_response: ItemsVec<Relationship, Cursor> = self
             .api_client
             .post("relationships/byids", &id_items)
             .await?;

--- a/cognite/src/api/iam/sessions.rs
+++ b/cognite/src/api/iam/sessions.rs
@@ -1,7 +1,7 @@
 use crate::api::resource::Resource;
 use crate::dto::iam::session::*;
 use crate::{CogniteId, Create, Items, List, Retrieve, WithBasePath};
-use crate::{ItemsWithoutCursor, Result};
+use crate::{ItemsVec, Result};
 
 /// Sessions are used to maintain access to CDF resources for an extended period of time.
 pub type SessionsResource = Resource<Session>;
@@ -21,9 +21,8 @@ impl SessionsResource {
     ///
     /// * `session_ids` - Sessions to revoke.
     pub async fn revoke(&self, session_ids: &[CogniteId]) -> Result<Vec<Session>> {
-        let items = Items::from(session_ids);
-        let response: ItemsWithoutCursor<Session> =
-            self.api_client.post("sessions/revoke", &items).await?;
+        let items = Items::new(session_ids);
+        let response: ItemsVec<Session> = self.api_client.post("sessions/revoke", &items).await?;
         Ok(response.items)
     }
 }

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -70,7 +70,7 @@ where
     fn list(
         &self,
         params: Option<TParams>,
-    ) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
+    ) -> impl Future<Output = Result<ItemsVec<TResponse, Cursor>>> + Send {
         async move {
             self.get_client()
                 .get_with_params(Self::BASE_PATH, params)
@@ -670,10 +670,10 @@ where
         filter: TFilter,
         cursor: Option<String>,
         limit: Option<u32>,
-    ) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
+    ) -> impl Future<Output = Result<ItemsVec<TResponse, Cursor>>> + Send {
         async move {
             let filter = Filter::<TFilter>::new(filter, cursor, limit);
-            let response: ItemsVec<TResponse> = self
+            let response: ItemsVec<TResponse, Cursor> = self
                 .get_client()
                 .post(&format!("{}/list", Self::BASE_PATH), &filter)
                 .await?;
@@ -717,9 +717,12 @@ where
     /// # Arguments
     ///
     /// * `filter` - Filter which items to retrieve.
-    fn filter(&self, filter: TFilter) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
+    fn filter(
+        &self,
+        filter: TFilter,
+    ) -> impl Future<Output = Result<ItemsVec<TResponse, Cursor>>> + Send {
         async move {
-            let response: ItemsVec<TResponse> = self
+            let response: ItemsVec<TResponse, Cursor> = self
                 .get_client()
                 .post(&format!("{}/list", Self::BASE_PATH), &filter)
                 .await?;

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -99,7 +99,7 @@ where
                 for it in response.items {
                     result.push(it);
                 }
-                match response.extra.next_cursor {
+                match response.extra_fields.next_cursor {
                     Some(cursor) => params.set_cursor(Some(cursor)),
                     None => return Ok(result),
                 }
@@ -148,7 +148,7 @@ where
                     .await?;
 
                 state.responses.extend(response.items);
-                state.next_cursor = match response.extra.next_cursor {
+                state.next_cursor = match response.extra_fields.next_cursor {
                     Some(x) => CursorState::Some(x),
                     None => CursorState::End,
                 };
@@ -429,7 +429,8 @@ where
         Self: Sync,
     {
         async move {
-            let req = Items::new_with_extra(deletes, IgnoreUnknownIds { ignore_unknown_ids });
+            let req =
+                Items::new_with_extra_fields(deletes, IgnoreUnknownIds { ignore_unknown_ids });
             self.get_client()
                 .post::<::serde_json::Value, _>(&format!("{}/delete", Self::BASE_PATH), &req)
                 .await?;
@@ -639,7 +640,7 @@ where
         ignore_unknown_ids: bool,
     ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let items = Items::new_with_extra(ids, IgnoreUnknownIds { ignore_unknown_ids });
+            let items = Items::new_with_extra_fields(ids, IgnoreUnknownIds { ignore_unknown_ids });
             let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/byids", Self::BASE_PATH), &items)
@@ -746,7 +747,7 @@ where
                 for it in response.items {
                     result.push(it);
                 }
-                match response.extra.next_cursor {
+                match response.extra_fields.next_cursor {
                     Some(cursor) => filter.set_cursor(Some(cursor)),
                     None => return Ok(result),
                 }
@@ -795,7 +796,7 @@ where
                     .await?;
 
                 state.responses.extend(response.items);
-                state.next_cursor = match response.extra.next_cursor {
+                state.next_cursor = match response.extra_fields.next_cursor {
                     Some(x) => CursorState::Some(x),
                     None => CursorState::End,
                 };

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -70,7 +70,7 @@ where
     fn list(
         &self,
         params: Option<TParams>,
-    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+    ) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
         async move {
             self.get_client()
                 .get_with_params(Self::BASE_PATH, params)
@@ -92,14 +92,14 @@ where
             let mut result = vec![];
             loop {
                 let lparams = params.clone();
-                let response: ItemsWithCursor<TResponse> = self
+                let response: ItemsVec<TResponse, Cursor> = self
                     .get_client()
                     .get_with_params(Self::BASE_PATH, Some(lparams))
                     .await?;
                 for it in response.items {
                     result.push(it);
                 }
-                match response.next_cursor {
+                match response.extra.next_cursor {
                     Some(cursor) => params.set_cursor(Some(cursor)),
                     None => return Ok(result),
                 }
@@ -142,13 +142,13 @@ where
                     }
                 };
                 state.req.set_cursor(cursor);
-                let response: ItemsWithCursor<TResponse> = self
+                let response: ItemsVec<TResponse, Cursor> = self
                     .get_client()
                     .get_with_params(Self::BASE_PATH, Some(state.req.clone()))
                     .await?;
 
                 state.responses.extend(response.items);
-                state.next_cursor = match response.next_cursor {
+                state.next_cursor = match response.extra.next_cursor {
                     Some(x) => CursorState::Some(x),
                     None => CursorState::End,
                 };
@@ -176,8 +176,8 @@ where
     /// `creates` - List of resources to create.
     fn create(&self, creates: &[TCreate]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let items = Items::from(creates);
-            let response: ItemsWithoutCursor<TResponse> =
+            let items = Items::new(creates);
+            let response: ItemsVec<TResponse> =
                 self.get_client().post(Self::BASE_PATH, &items).await?;
             Ok(response.items)
         }
@@ -228,8 +228,8 @@ where
                     return resp;
                 }
 
-                let items = Items::from(next);
-                let response: ItemsWithoutCursor<TResponse> =
+                let items = Items::new(next);
+                let response: ItemsVec<TResponse> =
                     self.get_client().post(Self::BASE_PATH, &items).await?;
                 Ok(response.items)
             } else {
@@ -282,8 +282,8 @@ where
         ignore_nulls: bool,
     ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let items = Items::from(upserts);
-            let resp: Result<ItemsWithoutCursor<TResponse>> =
+            let items = Items::new(upserts);
+            let resp: Result<ItemsVec<TResponse>> =
                 self.get_client().post(Self::BASE_PATH, &items).await;
 
             let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
@@ -305,18 +305,18 @@ where
 
                 let mut result = Vec::with_capacity(to_create.len() + to_update.len());
                 if !to_create.is_empty() {
-                    let mut create_response: ItemsWithoutCursor<TResponse> = self
+                    let mut create_response: ItemsVec<TResponse> = self
                         .get_client()
-                        .post(Self::BASE_PATH, &Items::from(to_create))
+                        .post(Self::BASE_PATH, &Items::new(to_create))
                         .await?;
                     result.append(&mut create_response.items);
                 }
                 if !to_update.is_empty() {
-                    let mut update_response: ItemsWithoutCursor<TResponse> = self
+                    let mut update_response: ItemsVec<TResponse> = self
                         .get_client()
                         .post(
                             &format!("{}/update", Self::BASE_PATH),
-                            &Items::from(&to_update),
+                            &Items::new(&to_update),
                         )
                         .await?;
                     result.append(&mut update_response.items);
@@ -353,7 +353,7 @@ pub trait UpsertCollection<TUpsert, TResponse> {
         Self: WithApiClient + WithBasePath + Sync,
     {
         async move {
-            let response: ItemsWithoutCursor<TResponse> =
+            let response: ItemsVec<TResponse> =
                 self.get_client().post(Self::BASE_PATH, &collection).await?;
             Ok(response.items)
         }
@@ -373,7 +373,7 @@ where
     /// * `deletes` - IDs of items to delete.
     fn delete(&self, deletes: &[TIdt]) -> impl Future<Output = Result<()>> + Send {
         async move {
-            let items = Items::from(deletes);
+            let items = Items::new(deletes);
             self.get_client()
                 .post::<::serde_json::Value, Items<&[TIdt]>>(
                     &format!("{}/delete", Self::BASE_PATH),
@@ -429,8 +429,7 @@ where
         Self: Sync,
     {
         async move {
-            let mut req = ItemsWithIgnoreUnknownIds::from(deletes);
-            req.ignore_unknown_ids = ignore_unknown_ids;
+            let req = Items::new_with_extra(deletes, IgnoreUnknownIds { ignore_unknown_ids });
             self.get_client()
                 .post::<::serde_json::Value, _>(&format!("{}/delete", Self::BASE_PATH), &req)
                 .await?;
@@ -452,13 +451,10 @@ where
     /// # Arguments
     ///
     /// * `deletes` - IDs of items to delete.
-    fn delete(
-        &self,
-        deletes: &[TIdt],
-    ) -> impl Future<Output = Result<ItemsWithoutCursor<TResponse>>> + Send {
+    fn delete(&self, deletes: &[TIdt]) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
         async move {
-            let items = Items::from(deletes);
-            let response: ItemsWithoutCursor<TResponse> = self
+            let items = Items::new(deletes);
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/delete", Self::BASE_PATH), &items)
                 .await?;
@@ -481,8 +477,8 @@ where
     /// * `updates` - Items to update.
     fn update(&self, updates: &[TUpdate]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let items = Items::from(updates);
-            let response: ItemsWithoutCursor<TResponse> = self
+            let items = Items::new(updates);
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/update", Self::BASE_PATH), &items)
                 .await?;
@@ -540,8 +536,8 @@ where
                     return response;
                 }
 
-                let items = Items::from(next);
-                let response: ItemsWithoutCursor<TResponse> = self
+                let items = Items::new(next);
+                let response: ItemsVec<TResponse> = self
                     .get_client()
                     .post(&format!("{}/update", Self::BASE_PATH), &items)
                     .await?;
@@ -589,8 +585,8 @@ where
     /// * `ids` - IDs of items to retrieve.
     fn retrieve(&self, ids: &[TIdt]) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let items = Items::from(ids);
-            let response: ItemsWithoutCursor<TResponse> = self
+            let items = Items::new(ids);
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/byids", Self::BASE_PATH), &items)
                 .await?;
@@ -643,9 +639,8 @@ where
         ignore_unknown_ids: bool,
     ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
-            let mut items = ItemsWithIgnoreUnknownIds::from(ids);
-            items.ignore_unknown_ids = ignore_unknown_ids;
-            let response: ItemsWithoutCursor<TResponse> = self
+            let items = Items::new_with_extra(ids, IgnoreUnknownIds { ignore_unknown_ids });
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/byids", Self::BASE_PATH), &items)
                 .await?;
@@ -674,10 +669,10 @@ where
         filter: TFilter,
         cursor: Option<String>,
         limit: Option<u32>,
-    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+    ) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
         async move {
             let filter = Filter::<TFilter>::new(filter, cursor, limit);
-            let response: ItemsWithCursor<TResponse> = self
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/list", Self::BASE_PATH), &filter)
                 .await?;
@@ -721,12 +716,9 @@ where
     /// # Arguments
     ///
     /// * `filter` - Filter which items to retrieve.
-    fn filter(
-        &self,
-        filter: TFilter,
-    ) -> impl Future<Output = Result<ItemsWithCursor<TResponse>>> + Send {
+    fn filter(&self, filter: TFilter) -> impl Future<Output = Result<ItemsVec<TResponse>>> + Send {
         async move {
-            let response: ItemsWithCursor<TResponse> = self
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/list", Self::BASE_PATH), &filter)
                 .await?;
@@ -747,14 +739,14 @@ where
         async move {
             let mut result = vec![];
             loop {
-                let response: ItemsWithCursor<TResponse> = self
+                let response: ItemsVec<TResponse, Cursor> = self
                     .get_client()
                     .post(&format!("{}/list", Self::BASE_PATH), &filter)
                     .await?;
                 for it in response.items {
                     result.push(it);
                 }
-                match response.next_cursor {
+                match response.extra.next_cursor {
                     Some(cursor) => filter.set_cursor(Some(cursor)),
                     None => return Ok(result),
                 }
@@ -797,13 +789,13 @@ where
                     }
                 };
                 state.req.set_cursor(cursor);
-                let response: ItemsWithCursor<TResponse> = self
+                let response: ItemsVec<TResponse, Cursor> = self
                     .get_client()
                     .post(&format!("{}/list", Self::BASE_PATH), &state.req)
                     .await?;
 
                 state.responses.extend(response.items);
-                state.next_cursor = match response.next_cursor {
+                state.next_cursor = match response.extra.next_cursor {
                     Some(x) => CursorState::Some(x),
                     None => CursorState::End,
                 };
@@ -872,7 +864,7 @@ where
     ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
             let req = Search::<TFilter, TSearch>::new(filter, search, limit);
-            let response: ItemsWithoutCursor<TResponse> = self
+            let response: ItemsVec<TResponse> = self
                 .get_client()
                 .post(&format!("{}/search", Self::BASE_PATH), &req)
                 .await?;

--- a/cognite/src/dto/items.rs
+++ b/cognite/src/dto/items.rs
@@ -1,99 +1,57 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-#[derive(Serialize, Deserialize, Debug)]
+/// A generic structure for handling items in requests and responses.
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// A wrapper around a list of items.
-pub struct Items<T> {
-    /// Collection of items.
-    pub items: T,
+pub struct Items<C, E = ()> {
+    /// The items of the request or response.
+    pub items: C,
+    /// Additional fields, delegated to the `E` type.
+    #[serde(flatten)]
+    pub extra: E,
 }
 
-impl<'a, T: Serialize> From<&'a Vec<T>> for Items<&'a Vec<T>> {
-    fn from(items: &'a Vec<T>) -> Self {
-        Items { items }
+impl<C> Items<C> {
+    /// Create a new `Items` instance with the provided items and no extra fields.
+    pub fn new(items: C) -> Self {
+        Self { items, extra: () }
     }
 }
 
-impl<'a, T: Serialize> From<Vec<&'a T>> for Items<Vec<&'a T>> {
-    fn from(items: Vec<&'a T>) -> Self {
-        Items { items }
+impl<C, E> Items<C, E> {
+    /// Create a new `Items` instance with the provided items and extra fields.
+    pub fn new_with_extra(items: C, extra: E) -> Self {
+        Self { items, extra }
     }
 }
 
-impl<'a, T: Serialize> From<&'a [T]> for Items<&'a [T]> {
-    fn from(items: &'a [T]) -> Self {
-        Items { items }
+impl<C, E: Default> From<C> for Items<C, E> {
+    fn from(items: C) -> Self {
+        Items {
+            items,
+            extra: E::default(),
+        }
     }
 }
 
+/// A convenience type for `Items` using a `Vec` to store items.
+pub type ItemsVec<T, E = ()> = Items<Vec<T>, E>;
+
+/// Extra fields for `Items` types with cursor data.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-/// A wrapper around a list of items, with cursor.
-pub struct ItemsWithCursor<T>
-where
-    T: Serialize,
-{
-    /// Collection of items.
-    pub items: Vec<T>,
-    /// Next cursor, for pagination.
+pub struct Cursor {
+    /// The cursor for the next page of items.
     pub next_cursor: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+/// Extra fields for `Items` types with the `ignoreUnknownIds` field.
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-/// A wrapper around a list of items, without cursor.
-pub struct ItemsWithoutCursor<T>
-where
-    T: Serialize,
-{
-    /// Collection of items.
-    pub items: Vec<T>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-/// A wrapper around a list of items, with ignore unknown ids.
-pub struct ItemsWithIgnoreUnknownIds<T> {
-    /// Collection of items.
-    pub items: T,
-    /// `true` to ignore unknown IDs.
+#[skip_serializing_none]
+pub struct IgnoreUnknownIds {
+    /// Whether to ignore unknown IDs in the request.
     pub ignore_unknown_ids: bool,
-}
-
-impl<T> ItemsWithIgnoreUnknownIds<T> {
-    /// Create a new items collection with ignore unknown IDs.
-    ///
-    /// # Arguments
-    ///
-    /// * `items` - Collection of items.
-    /// * `ignore_unknown_ids` - `true` to ignore unknown IDs.
-    pub fn new(items: T, ignore_unknown_ids: bool) -> Self
-    where
-        T: Serialize,
-    {
-        Self {
-            items,
-            ignore_unknown_ids,
-        }
-    }
-}
-
-impl<'a, T: Serialize> From<&'a Vec<T>> for ItemsWithIgnoreUnknownIds<&'a Vec<T>> {
-    fn from(items: &'a Vec<T>) -> Self {
-        ItemsWithIgnoreUnknownIds {
-            items,
-            ignore_unknown_ids: true,
-        }
-    }
-}
-
-impl<'a, T: Serialize> From<&'a [T]> for ItemsWithIgnoreUnknownIds<&'a [T]> {
-    fn from(items: &'a [T]) -> Self {
-        ItemsWithIgnoreUnknownIds {
-            items,
-            ignore_unknown_ids: true,
-        }
-    }
 }

--- a/cognite/src/dto/items.rs
+++ b/cognite/src/dto/items.rs
@@ -9,20 +9,26 @@ pub struct Items<C, E = ()> {
     pub items: C,
     /// Additional fields, delegated to the `E` type.
     #[serde(flatten)]
-    pub extra: E,
+    pub extra_fields: E,
 }
 
 impl<C> Items<C> {
     /// Create a new `Items` instance with the provided items and no extra fields.
     pub fn new(items: C) -> Self {
-        Self { items, extra: () }
+        Self {
+            items,
+            extra_fields: (),
+        }
     }
 }
 
 impl<C, E> Items<C, E> {
     /// Create a new `Items` instance with the provided items and extra fields.
-    pub fn new_with_extra(items: C, extra: E) -> Self {
-        Self { items, extra }
+    pub fn new_with_extra_fields(items: C, extra_fields: E) -> Self {
+        Self {
+            items,
+            extra_fields,
+        }
     }
 }
 
@@ -30,7 +36,7 @@ impl<C, E: Default> From<C> for Items<C, E> {
     fn from(items: C) -> Self {
         Items {
             items,
-            extra: E::default(),
+            extra_fields: E::default(),
         }
     }
 }


### PR DESCRIPTION
There are multiple different types (`Items`, `ItemsWithCursor`, `ItemsWithoutCursor`, `ItemsWithIgnoreUnknownIds`) that all represent the same basic structure: `{"items":[...], ...}`. The reduce code duplication, I'm proposing that this is changed to have a single base type (`Items`) which is generic enough to work with all of these cases:

```
#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
pub struct Items<C, E = ()> {
    pub items: C,
    #[serde(flatten)]
    pub extra_fields: E,
}
```

The `items` field should be a collection of items, such as `Vec<T>` or `&[T]`.

The `extra_fields` field can be used to extend the list object with additional fields. In this PR, two additional types are defined for this purpose: `Cursor`, which adds the `nextCursor` field, and `IgnoreUnknownIds`, which adds the `ignoreUnknownIds` field.

In addition, `ItemsVec<T, E = ()>` is added as a convenience alias for `Items<Vec<T>, E>`, effectively replacing the existing `ItemsWithoutCursor`.

---

As this is a breaking change, the version of this SDK should be bumped after merging. As this is also the case the parallel PR #217, I propose doing so in a separate PR to merged after these two.