### PR TITLE
Rename AsParams->IntoParams and add impl for Vec

### DIFF
--- a/cognite/src/api/api_client.rs
+++ b/cognite/src/api/api_client.rs
@@ -1,4 +1,4 @@
-use crate::AsParams;
+use crate::IntoParams;
 use anyhow::anyhow;
 use futures::{TryStream, TryStreamExt};
 use prost::Message;
@@ -139,13 +139,13 @@ impl ApiClient {
     ///
     /// * `path` - Request path, without leading slash.
     /// * `params` - Optional object converted to query parameters.
-    pub async fn get_with_params<T: DeserializeOwned, R: AsParams>(
+    pub async fn get_with_params<T: DeserializeOwned, R: IntoParams>(
         &self,
         path: &str,
         params: Option<R>,
     ) -> Result<T> {
         let http_params = match params {
-            Some(params) => params.to_tuples(),
+            Some(params) => params.into_params(),
             None => return self.get::<T>(path).await,
         };
 
@@ -222,14 +222,14 @@ impl ApiClient {
     /// * `path` - Request path, without leading slash.
     /// * `object` - Object converted to JSON body.
     /// * `params` - Object converted to query parameters.
-    pub async fn post_with_query<D: DeserializeOwned, S: Serialize, R: AsParams>(
+    pub async fn post_with_query<D: DeserializeOwned, S: Serialize, R: IntoParams>(
         &self,
         path: &str,
         object: &S,
         params: Option<R>,
     ) -> Result<D> {
         let http_params = match params {
-            Some(params) => params.to_tuples(),
+            Some(params) => params.into_params(),
             None => return self.post::<D, S>(path, object).await,
         };
         let json = match serde_json::to_string(object) {
@@ -430,13 +430,13 @@ impl ApiClient {
     ///
     /// * `path` - Request path without leading slash.
     /// * `params` - Object converted to query parameters.
-    pub async fn delete_with_params<T: DeserializeOwned, R: AsParams>(
+    pub async fn delete_with_params<T: DeserializeOwned, R: IntoParams>(
         &self,
         path: &str,
         params: Option<R>,
     ) -> Result<T> {
         let http_params = match params {
-            Some(params) => params.to_tuples(),
+            Some(params) => params.into_params(),
             None => return self.delete::<T>(path).await,
         };
 

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -9,8 +9,8 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::dto::items::*;
 use crate::{
-    ApiClient, AsParams, EqIdentity, Filter, Identity, IntoPatch, Partition, Patch, Result, Search,
-    SetCursor, WithPartition,
+    ApiClient, EqIdentity, Filter, Identity, IntoParams, IntoPatch, Partition, Patch, Result,
+    Search, SetCursor, WithPartition,
 };
 
 use super::utils::{get_duplicates_from_result, get_missing_from_result};
@@ -58,7 +58,7 @@ pub trait WithBasePath {
 /// Trait for simple GET / endpoints.
 pub trait List<TParams, TResponse>
 where
-    TParams: AsParams + Send + Sync + 'static,
+    TParams: IntoParams + Send + Sync + 'static,
     TResponse: Serialize + DeserializeOwned + Send + Sync,
     Self: WithApiClient + WithBasePath + Sync,
 {

--- a/cognite/src/dto/core/asset/filter.rs
+++ b/cognite/src/dto/core/asset/filter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dto::core::common::CoreSortItem, to_query, AdvancedFilter, AsParams, Identity, LabelsFilter,
+    dto::core::common::CoreSortItem, to_query, AdvancedFilter, Identity, IntoParams, LabelsFilter,
     Partition, Range, SetCursor, WithPartition,
 };
 use serde::{Deserialize, Serialize};
@@ -141,8 +141,8 @@ pub struct AssetQuery {
     pub partition: Option<Partition>,
 }
 
-impl AsParams for AssetQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for AssetQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);

--- a/cognite/src/dto/core/event/filter.rs
+++ b/cognite/src/dto/core/event/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     dto::core::common::CoreSortItem, to_query, to_query_vec, to_query_vec_i64, AdvancedFilter,
-    AsParams, Identity, Partition, Range, SetCursor, WithPartition,
+    Identity, IntoParams, Partition, Range, SetCursor, WithPartition,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -71,8 +71,8 @@ pub struct EventQuery {
     pub sort: Option<Vec<String>>,
 }
 
-impl AsParams for EventQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for EventQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);

--- a/cognite/src/dto/core/files/filter.rs
+++ b/cognite/src/dto/core/files/filter.rs
@@ -1,4 +1,4 @@
-use crate::{AsParams, Identity, LabelsFilter, Range};
+use crate::{Identity, IntoParams, LabelsFilter, Range};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -73,8 +73,8 @@ pub struct FileUploadQuery {
     pub overwrite: bool,
 }
 
-impl AsParams for FileUploadQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for FileUploadQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         if self.overwrite {
             vec![("overwrite".to_string(), "true".to_string())]
         } else {

--- a/cognite/src/dto/core/time_series/filter.rs
+++ b/cognite/src/dto/core/time_series/filter.rs
@@ -2,7 +2,7 @@ use crate::dto::core::common::CoreSortItem;
 use crate::{
     to_query, to_query_vec_i64, AdvancedFilter, Identity, Partition, SetCursor, WithPartition,
 };
-use crate::{AsParams, Range};
+use crate::{IntoParams, Range};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
@@ -96,8 +96,8 @@ pub struct TimeSeriesQuery {
     pub root_asset_ids: Option<Vec<i64>>,
 }
 
-impl AsParams for TimeSeriesQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for TimeSeriesQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("includeMetadata", &self.include_metadata, &mut params);

--- a/cognite/src/dto/data_ingestion/raw.rs
+++ b/cognite/src/dto/data_ingestion/raw.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{to_query, AsParams, SetCursor};
+use crate::{to_query, IntoParams, SetCursor};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -68,8 +68,8 @@ pub struct RetrieveCursorsQuery {
     pub number_of_cursors: Option<i32>,
 }
 
-impl AsParams for RetrieveCursorsQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for RetrieveCursorsQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query(
             "minLastUpdatedTime",
@@ -102,8 +102,8 @@ pub struct RetrieveRowsQuery {
     pub max_last_updated_time: Option<i64>,
 }
 
-impl AsParams for RetrieveRowsQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for RetrieveRowsQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         if let Some(columns) = self.columns {
@@ -151,8 +151,8 @@ impl EnsureParentQuery {
     }
 }
 
-impl AsParams for EnsureParentQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for EnsureParentQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("ensureParent", &self.ensure_parent, &mut params);
         params

--- a/cognite/src/dto/data_modeling/containers.rs
+++ b/cognite/src/dto/data_modeling/containers.rs
@@ -5,7 +5,7 @@ use serde_with::skip_serializing_none;
 
 use crate::{
     models::{TaggedContainerReference, UsedFor},
-    to_query, AsParams, RawValue, SetCursor,
+    to_query, IntoParams, RawValue, SetCursor,
 };
 
 use super::common::{CDFExternalIdReference, PrimitiveProperty, TextProperty};
@@ -202,8 +202,8 @@ pub struct ContainerQuery {
     pub include_global: Option<bool>,
 }
 
-impl AsParams for ContainerQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for ContainerQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);

--- a/cognite/src/dto/data_modeling/data_models.rs
+++ b/cognite/src/dto/data_modeling/data_models.rs
@@ -3,7 +3,7 @@ use serde_with::skip_serializing_none;
 
 use crate::{
     models::views::{ViewCreateOrReference, ViewDefinitionOrReference},
-    to_query, AsParams, SetCursor,
+    to_query, IntoParams, SetCursor,
 };
 
 #[skip_serializing_none]
@@ -101,8 +101,8 @@ impl SetCursor for DataModelQuery {
     }
 }
 
-impl AsParams for DataModelQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for DataModelQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::new();
         to_query("cursor", &self.cursor, &mut params);
         to_query("limit", &self.limit, &mut params);

--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -9,7 +9,7 @@ use crate::{
         CDFExternalIdReference, PrimitiveProperty, SourceReference, TaggedContainerReference,
         TaggedViewReference, TextProperty, UsedFor,
     },
-    to_query, AdvancedFilter, AsParams, RawValue, SetCursor,
+    to_query, AdvancedFilter, IntoParams, RawValue, SetCursor,
 };
 
 use super::{
@@ -46,8 +46,8 @@ pub struct ViewQuery {
     pub include_global: Option<bool>,
 }
 
-impl AsParams for ViewQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for ViewQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);

--- a/cognite/src/dto/iam/group.rs
+++ b/cognite/src/dto/iam/group.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{to_query, AsParams};
+use crate::{to_query, IntoParams};
 
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -63,8 +63,8 @@ pub struct GroupQuery {
     pub all: Option<bool>,
 }
 
-impl AsParams for GroupQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for GroupQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("all", &self.all, &mut params);
         params

--- a/cognite/src/dto/iam/security_category.rs
+++ b/cognite/src/dto/iam/security_category.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{models::SortDirection, to_query, AsParams, SetCursor};
+use crate::{models::SortDirection, to_query, IntoParams, SetCursor};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -31,8 +31,8 @@ pub struct SecurityCategoryQuery {
     pub limit: Option<i32>,
 }
 
-impl AsParams for SecurityCategoryQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for SecurityCategoryQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query(
             "sort",

--- a/cognite/src/dto/iam/session.rs
+++ b/cognite/src/dto/iam/session.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{to_query, AsParams, SetCursor};
+use crate::{to_query, IntoParams, SetCursor};
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -50,8 +50,8 @@ impl SetCursor for SessionQuery {
     }
 }
 
-impl AsParams for SessionQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for SessionQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = vec![];
         to_query("status", &self.status, &mut params);
         to_query("cursor", &self.cursor, &mut params);

--- a/cognite/src/dto/params.rs
+++ b/cognite/src/dto/params.rs
@@ -3,9 +3,15 @@ use std::fmt::Display;
 use crate::Partition;
 
 /// Trait for query parameters.
-pub trait AsParams {
+pub trait IntoParams {
     /// Convert self to a list of query parameter tuples.
-    fn to_tuples(self) -> Vec<(String, String)>;
+    fn into_params(self) -> Vec<(String, String)>;
+}
+
+impl IntoParams for Vec<(String, String)> {
+    fn into_params(self) -> Vec<(String, String)> {
+        self
+    }
 }
 
 /// Push the item given in `item` to the query with name `name` if it is Some.
@@ -61,8 +67,8 @@ pub struct LimitCursorQuery {
     pub cursor: Option<String>,
 }
 
-impl AsParams for LimitCursorQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for LimitCursorQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);
@@ -80,8 +86,8 @@ pub struct LimitCursorPartitionQuery {
     pub partition: Option<Partition>,
 }
 
-impl AsParams for LimitCursorPartitionQuery {
-    fn to_tuples(self) -> Vec<(String, String)> {
+impl IntoParams for LimitCursorPartitionQuery {
+    fn into_params(self) -> Vec<(String, String)> {
         let mut params = Vec::<(String, String)>::new();
         to_query("limit", &self.limit, &mut params);
         to_query("cursor", &self.cursor, &mut params);


### PR DESCRIPTION
By [convention][1], traits and methods taking `owned -> owned` should be named `into_*`, whereas `as_*` should be used for traits and methods taking `borrowed -> borrowed` and `to_*` for taking `borrowed -> borrowed/owned`. Additionally, it is common for single-method traits to have the same name for the method and trait.

For this reason, I propose to rename `AsParams` into `IntoParams` and `AsParams::to_tuples` into `IntoParams::into_params`.

Additionally, to enable usage of custom parameters in `ApiClient` (such as [`ApiClient::get_with_params`][2]) without defining a custom type on usage, I propose adding an implemention of `IntoParams` for `Vec<(String, String)>`.

---

As this is a breaking change, the version of this SDK should be bumped after merging. As this is also the case the parallel PR #216, I propose doing so in a separate PR to merged after these two.


[1]: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv
[2]: https://github.com/cognitedata/cognite-sdk-rust/blob/bfcd268ba9b59f387daa1e4f5fc54b88f0cf6fd3/cognite/src/api/api_client.rs#L142