### PR TITLE
Options for upsert

### DIFF
--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::dto::items::*;
 use crate::{
     ApiClient, EqIdentity, Filter, Identity, IntoParams, IntoPatch, Partition, Patch, Result,
-    Search, SetCursor, WithPartition,
+    Search, SetCursor, UpsertOptions, WithPartition,
 };
 
 use super::utils::{get_duplicates_from_result, get_missing_from_result};
@@ -273,13 +273,11 @@ where
     /// # Arguments
     ///
     /// * `upserts` - Resources to insert or update.
-    /// * `ignore_nulls` - Behavior for values that are `None`. If this is `true`,
-    /// `None` values will simply be ignored. Otherwise, fields with `None` values
-    /// will be set to null in CDF.
+    /// * `options` - Configuration for upserts, which fields are kept and which are overwritten.
     fn upsert(
         &'a self,
         upserts: &'a [TCreate],
-        ignore_nulls: bool,
+        options: &UpsertOptions,
     ) -> impl Future<Output = Result<Vec<TResponse>>> + Send {
         async move {
             let items = Items::new(upserts);
@@ -296,7 +294,7 @@ where
                     if let Some(idt) = idt {
                         to_update.push(Patch::<TUpdate> {
                             id: idt.clone(),
-                            update: it.clone().patch(ignore_nulls),
+                            update: it.clone().patch(options),
                         });
                     } else {
                         to_create.push(it);

--- a/cognite/src/dto/core/asset/mod.rs
+++ b/cognite/src/dto/core/asset/mod.rs
@@ -5,6 +5,7 @@ pub use self::aggregate::*;
 pub use self::filter::*;
 
 use crate::dto::identity::Identity;
+use crate::UpsertOptions;
 use crate::{CogniteExternalId, CogniteId, EqIdentity, IntoPatch, IntoPatchItem, UpdateList};
 use crate::{Patch, UpdateMap, UpdateSet, UpdateSetNull};
 use serde::{Deserialize, Serialize};
@@ -210,52 +211,52 @@ pub struct PatchAsset {
 }
 
 impl IntoPatch<Patch<PatchAsset>> for Asset {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchAsset> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchAsset> {
         Patch::<PatchAsset> {
             id: to_idt!(self),
             update: PatchAsset {
-                external_id: self.external_id.patch(ignore_nulls),
-                name: self.name.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                source: self.source.patch(ignore_nulls),
-                parent_id: self.parent_id.and_then(|p| p.patch(ignore_nulls)),
+                external_id: self.external_id.patch(options),
+                name: self.name.patch(options),
+                description: self.description.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                metadata: self.metadata.patch(options),
+                source: self.source.patch(options),
+                parent_id: self.parent_id.and_then(|p| p.patch(options)),
                 parent_external_id: None,
-                labels: self.labels.patch(ignore_nulls),
-                geo_location: self.geo_location.patch(ignore_nulls),
+                labels: self.labels.patch(options),
+                geo_location: self.geo_location.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchAsset> for AddAsset {
-    fn patch(self, ignore_nulls: bool) -> PatchAsset {
+    fn patch(self, options: &UpsertOptions) -> PatchAsset {
         let mut parent_id = None;
         let mut parent_external_id = None;
         if let Some(p_id) = self.parent_id {
-            parent_id = p_id.patch(ignore_nulls);
+            parent_id = p_id.patch(options);
         } else if let Some(p_extid) = self.parent_external_id {
-            parent_external_id = p_extid.patch(ignore_nulls);
+            parent_external_id = p_extid.patch(options);
         }
         PatchAsset {
-            external_id: self.external_id.patch(ignore_nulls),
-            name: self.name.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            source: self.source.patch(ignore_nulls),
+            external_id: self.external_id.patch(options),
+            name: self.name.patch(options),
+            description: self.description.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            metadata: self.metadata.patch(options),
+            source: self.source.patch(options),
             parent_id,
             parent_external_id,
-            labels: self.labels.patch(ignore_nulls),
-            geo_location: self.geo_location.patch(ignore_nulls),
+            labels: self.labels.patch(options),
+            geo_location: self.geo_location.patch(options),
         }
     }
 }
 
 impl From<Asset> for Patch<PatchAsset> {
     fn from(value: Asset) -> Self {
-        IntoPatch::<Patch<PatchAsset>>::patch(value, false)
+        IntoPatch::<Patch<PatchAsset>>::patch(value, &Default::default())
     }
 }
 

--- a/cognite/src/dto/core/event/mod.rs
+++ b/cognite/src/dto/core/event/mod.rs
@@ -4,6 +4,7 @@ mod filter;
 pub use self::aggregate::*;
 pub use self::filter::*;
 
+use crate::UpsertOptions;
 use crate::{
     EqIdentity, Identity, IntoPatch, IntoPatchItem, Patch, UpdateList, UpdateMap, UpdateSetNull,
 };
@@ -133,44 +134,44 @@ pub struct PatchEvent {
 }
 
 impl IntoPatch<Patch<PatchEvent>> for Event {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchEvent> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchEvent> {
         Patch::<PatchEvent> {
             id: to_idt!(self),
             update: PatchEvent {
-                external_id: self.external_id.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                start_time: self.start_time.patch(ignore_nulls),
-                end_time: self.end_time.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                asset_ids: self.asset_ids.patch(ignore_nulls),
-                source: self.source.patch(ignore_nulls),
-                r#type: self.r#type.patch(ignore_nulls),
-                subtype: self.subtype.patch(ignore_nulls),
+                external_id: self.external_id.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                start_time: self.start_time.patch(options),
+                end_time: self.end_time.patch(options),
+                description: self.description.patch(options),
+                metadata: self.metadata.patch(options),
+                asset_ids: self.asset_ids.patch(options),
+                source: self.source.patch(options),
+                r#type: self.r#type.patch(options),
+                subtype: self.subtype.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchEvent> for AddEvent {
-    fn patch(self, ignore_nulls: bool) -> PatchEvent {
+    fn patch(self, options: &UpsertOptions) -> PatchEvent {
         PatchEvent {
-            external_id: self.external_id.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            start_time: self.start_time.patch(ignore_nulls),
-            end_time: self.end_time.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            asset_ids: self.asset_ids.patch(ignore_nulls),
-            source: self.source.patch(ignore_nulls),
-            r#type: self.r#type.patch(ignore_nulls),
-            subtype: self.subtype.patch(ignore_nulls),
+            external_id: self.external_id.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            start_time: self.start_time.patch(options),
+            end_time: self.end_time.patch(options),
+            description: self.description.patch(options),
+            metadata: self.metadata.patch(options),
+            asset_ids: self.asset_ids.patch(options),
+            source: self.source.patch(options),
+            r#type: self.r#type.patch(options),
+            subtype: self.subtype.patch(options),
         }
     }
 }
 
 impl From<Event> for Patch<PatchEvent> {
     fn from(value: Event) -> Self {
-        IntoPatch::<Patch<PatchEvent>>::patch(value, false)
+        IntoPatch::<Patch<PatchEvent>>::patch(value, &Default::default())
     }
 }

--- a/cognite/src/dto/core/files/file.rs
+++ b/cognite/src/dto/core/files/file.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::{
     CogniteExternalId, EqIdentity, Identity, IntoPatch, IntoPatchItem, Patch, UpdateList,
-    UpdateMap, UpdateSetNull,
+    UpdateMap, UpdateSetNull, UpsertOptions,
 };
 
 #[skip_serializing_none]
@@ -146,47 +146,47 @@ pub struct PatchFile {
 }
 
 impl IntoPatch<Patch<PatchFile>> for FileMetadata {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchFile> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchFile> {
         Patch::<PatchFile> {
             id: to_idt!(self),
             update: PatchFile {
-                external_id: self.external_id.patch(ignore_nulls),
-                directory: self.directory.patch(ignore_nulls),
-                source: self.source.patch(ignore_nulls),
-                mime_type: self.mime_type.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                asset_ids: self.asset_ids.patch(ignore_nulls),
-                source_created_time: self.source_created_time.patch(ignore_nulls),
-                source_modified_time: self.source_modified_time.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                security_categories: self.security_categories.patch(ignore_nulls),
-                labels: self.labels.patch(ignore_nulls),
+                external_id: self.external_id.patch(options),
+                directory: self.directory.patch(options),
+                source: self.source.patch(options),
+                mime_type: self.mime_type.patch(options),
+                metadata: self.metadata.patch(options),
+                asset_ids: self.asset_ids.patch(options),
+                source_created_time: self.source_created_time.patch(options),
+                source_modified_time: self.source_modified_time.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                security_categories: self.security_categories.patch(options),
+                labels: self.labels.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchFile> for AddFile {
-    fn patch(self, ignore_nulls: bool) -> PatchFile {
+    fn patch(self, options: &UpsertOptions) -> PatchFile {
         PatchFile {
-            external_id: self.external_id.patch(ignore_nulls),
-            directory: self.directory.patch(ignore_nulls),
-            source: self.source.patch(ignore_nulls),
-            mime_type: self.mime_type.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            asset_ids: self.asset_ids.patch(ignore_nulls),
-            source_created_time: self.source_created_time.patch(ignore_nulls),
-            source_modified_time: self.source_modified_time.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            security_categories: self.security_categories.patch(ignore_nulls),
-            labels: self.labels.patch(ignore_nulls),
+            external_id: self.external_id.patch(options),
+            directory: self.directory.patch(options),
+            source: self.source.patch(options),
+            mime_type: self.mime_type.patch(options),
+            metadata: self.metadata.patch(options),
+            asset_ids: self.asset_ids.patch(options),
+            source_created_time: self.source_created_time.patch(options),
+            source_modified_time: self.source_modified_time.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            security_categories: self.security_categories.patch(options),
+            labels: self.labels.patch(options),
         }
     }
 }
 
 impl From<FileMetadata> for Patch<PatchFile> {
     fn from(file: FileMetadata) -> Self {
-        IntoPatch::<Patch<PatchFile>>::patch(file, false)
+        IntoPatch::<Patch<PatchFile>>::patch(file, &Default::default())
     }
 }
 

--- a/cognite/src/dto/core/sequences.rs
+++ b/cognite/src/dto/core/sequences.rs
@@ -1,6 +1,6 @@
 use crate::{
     AdvancedFilter, EqIdentity, Identity, IntoPatch, IntoPatchItem, Partition, Patch, Range,
-    SetCursor, UpdateList, UpdateMap, UpdateSet, UpdateSetNull, WithPartition,
+    SetCursor, UpdateList, UpdateMap, UpdateSet, UpdateSetNull, UpsertOptions, WithPartition,
 };
 
 use serde::{Deserialize, Serialize};
@@ -196,16 +196,16 @@ pub struct PatchSequence {
 }
 
 impl IntoPatch<Patch<PatchSequence>> for Sequence {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchSequence> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchSequence> {
         Patch::<PatchSequence> {
             id: to_idt!(self),
             update: PatchSequence {
-                name: self.name.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                asset_id: self.asset_id.patch(ignore_nulls),
-                external_id: self.external_id.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
+                name: self.name.patch(options),
+                description: self.description.patch(options),
+                asset_id: self.asset_id.patch(options),
+                external_id: self.external_id.patch(options),
+                metadata: self.metadata.patch(options),
+                data_set_id: self.data_set_id.patch(options),
                 columns: None,
             },
         }
@@ -213,14 +213,14 @@ impl IntoPatch<Patch<PatchSequence>> for Sequence {
 }
 
 impl IntoPatch<PatchSequence> for AddSequence {
-    fn patch(self, ignore_nulls: bool) -> PatchSequence {
+    fn patch(self, options: &UpsertOptions) -> PatchSequence {
         PatchSequence {
-            name: self.name.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            asset_id: self.asset_id.patch(ignore_nulls),
-            external_id: self.external_id.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
+            name: self.name.patch(options),
+            description: self.description.patch(options),
+            asset_id: self.asset_id.patch(options),
+            external_id: self.external_id.patch(options),
+            metadata: self.metadata.patch(options),
+            data_set_id: self.data_set_id.patch(options),
             columns: None,
         }
     }
@@ -228,7 +228,7 @@ impl IntoPatch<PatchSequence> for AddSequence {
 
 impl From<Sequence> for Patch<PatchSequence> {
     fn from(sequence: Sequence) -> Self {
-        IntoPatch::<Patch<PatchSequence>>::patch(sequence, false)
+        IntoPatch::<Patch<PatchSequence>>::patch(sequence, &Default::default())
     }
 }
 

--- a/cognite/src/dto/core/time_series/mod.rs
+++ b/cognite/src/dto/core/time_series/mod.rs
@@ -6,6 +6,7 @@ pub use self::synthetic::*;
 
 use crate::IntoPatch;
 use crate::IntoPatchItem;
+use crate::UpsertOptions;
 use crate::{EqIdentity, Identity, Patch, UpdateList, UpdateMap, UpdateSet, UpdateSetNull};
 
 use serde::{Deserialize, Serialize};
@@ -136,44 +137,44 @@ pub struct PatchTimeSeries {
 }
 
 impl IntoPatch<Patch<PatchTimeSeries>> for TimeSeries {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchTimeSeries> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchTimeSeries> {
         Patch::<PatchTimeSeries> {
             id: to_idt!(self),
             update: PatchTimeSeries {
-                name: self.name.patch(ignore_nulls),
-                external_id: self.external_id.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                unit: self.unit.patch(ignore_nulls),
-                unit_external_id: self.unit_external_id.patch(ignore_nulls),
-                asset_id: self.asset_id.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                security_categories: self.security_categories.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                is_step: self.is_step.patch(ignore_nulls),
+                name: self.name.patch(options),
+                external_id: self.external_id.patch(options),
+                metadata: self.metadata.patch(options),
+                unit: self.unit.patch(options),
+                unit_external_id: self.unit_external_id.patch(options),
+                asset_id: self.asset_id.patch(options),
+                description: self.description.patch(options),
+                security_categories: self.security_categories.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                is_step: self.is_step.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchTimeSeries> for AddTimeSeries {
-    fn patch(self, ignore_nulls: bool) -> PatchTimeSeries {
+    fn patch(self, options: &UpsertOptions) -> PatchTimeSeries {
         PatchTimeSeries {
-            name: self.name.patch(ignore_nulls),
-            external_id: self.external_id.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            unit: self.unit.patch(ignore_nulls),
-            unit_external_id: self.unit_external_id.patch(ignore_nulls),
-            asset_id: self.asset_id.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            security_categories: self.security_categories.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            is_step: self.is_step.patch(ignore_nulls),
+            name: self.name.patch(options),
+            external_id: self.external_id.patch(options),
+            metadata: self.metadata.patch(options),
+            unit: self.unit.patch(options),
+            unit_external_id: self.unit_external_id.patch(options),
+            asset_id: self.asset_id.patch(options),
+            description: self.description.patch(options),
+            security_categories: self.security_categories.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            is_step: self.is_step.patch(options),
         }
     }
 }
 
 impl From<TimeSeries> for Patch<PatchTimeSeries> {
     fn from(time_serie: TimeSeries) -> Patch<PatchTimeSeries> {
-        IntoPatch::<Patch<PatchTimeSeries>>::patch(time_serie, false)
+        IntoPatch::<Patch<PatchTimeSeries>>::patch(time_serie, &Default::default())
     }
 }

--- a/cognite/src/dto/data_ingestion/extpipes.rs
+++ b/cognite/src/dto/data_ingestion/extpipes.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateList, UpdateMap, UpdateSet};
+use crate::{
+    Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateList, UpdateMap, UpdateSet,
+    UpsertOptions,
+};
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -149,47 +152,47 @@ pub struct PatchExtPipe {
 }
 
 impl IntoPatch<Patch<PatchExtPipe>> for ExtPipe {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchExtPipe> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchExtPipe> {
         Patch::<PatchExtPipe> {
             id: Identity::ExternalId {
                 external_id: self.external_id,
             },
             update: PatchExtPipe {
                 external_id: None,
-                name: self.name.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                schedule: self.schedule.patch(ignore_nulls),
-                raw_tables: self.raw_tables.patch(ignore_nulls),
-                contacts: self.contacts.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
-                source: self.source.patch(ignore_nulls),
-                documentation: self.documentation.patch(ignore_nulls),
+                name: self.name.patch(options),
+                description: self.description.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                schedule: self.schedule.patch(options),
+                raw_tables: self.raw_tables.patch(options),
+                contacts: self.contacts.patch(options),
+                metadata: self.metadata.patch(options),
+                source: self.source.patch(options),
+                documentation: self.documentation.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchExtPipe> for AddExtPipe {
-    fn patch(self, ignore_nulls: bool) -> PatchExtPipe {
+    fn patch(self, options: &UpsertOptions) -> PatchExtPipe {
         PatchExtPipe {
-            external_id: self.external_id.patch(ignore_nulls),
-            name: self.name.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            schedule: self.schedule.patch(ignore_nulls),
-            raw_tables: self.raw_tables.patch(ignore_nulls),
-            contacts: self.contacts.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
-            source: self.source.patch(ignore_nulls),
-            documentation: self.documentation.patch(ignore_nulls),
+            external_id: self.external_id.patch(options),
+            name: self.name.patch(options),
+            description: self.description.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            schedule: self.schedule.patch(options),
+            raw_tables: self.raw_tables.patch(options),
+            contacts: self.contacts.patch(options),
+            metadata: self.metadata.patch(options),
+            source: self.source.patch(options),
+            documentation: self.documentation.patch(options),
         }
     }
 }
 
 impl From<ExtPipe> for Patch<PatchExtPipe> {
     fn from(sequence: ExtPipe) -> Self {
-        IntoPatch::<Patch<PatchExtPipe>>::patch(sequence, false)
+        IntoPatch::<Patch<PatchExtPipe>>::patch(sequence, &Default::default())
     }
 }
 

--- a/cognite/src/dto/data_organization/datasets.rs
+++ b/cognite/src/dto/data_organization/datasets.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateMap, UpdateSetNull};
+use crate::{
+    Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateMap, UpdateSetNull, UpsertOptions,
+};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
@@ -105,32 +107,32 @@ pub struct PatchDataSet {
 }
 
 impl IntoPatch<Patch<PatchDataSet>> for DataSet {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchDataSet> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchDataSet> {
         Patch::<PatchDataSet> {
             id: to_idt!(self),
             update: PatchDataSet {
                 external_id: None,
-                name: self.name.patch(ignore_nulls),
-                description: self.description.patch(ignore_nulls),
-                metadata: self.metadata.patch(ignore_nulls),
+                name: self.name.patch(options),
+                description: self.description.patch(options),
+                metadata: self.metadata.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchDataSet> for AddDataSet {
-    fn patch(self, ignore_nulls: bool) -> PatchDataSet {
+    fn patch(self, options: &UpsertOptions) -> PatchDataSet {
         PatchDataSet {
             external_id: None,
-            name: self.name.patch(ignore_nulls),
-            description: self.description.patch(ignore_nulls),
-            metadata: self.metadata.patch(ignore_nulls),
+            name: self.name.patch(options),
+            description: self.description.patch(options),
+            metadata: self.metadata.patch(options),
         }
     }
 }
 
 impl From<DataSet> for Patch<PatchDataSet> {
     fn from(data_set: DataSet) -> Patch<PatchDataSet> {
-        IntoPatch::<Patch<PatchDataSet>>::patch(data_set, false)
+        IntoPatch::<Patch<PatchDataSet>>::patch(data_set, &Default::default())
     }
 }

--- a/cognite/src/dto/data_organization/relationships.rs
+++ b/cognite/src/dto/data_organization/relationships.rs
@@ -6,7 +6,7 @@ use crate::sequences::Sequence;
 use crate::time_series::TimeSeries;
 use crate::{
     CogniteExternalId, Identity, IntoPatch, IntoPatchItem, LabelsFilter, Partition, Patch, Range,
-    SetCursor, UpdateList, UpdateSet, UpdateSetNull, WithPartition,
+    SetCursor, UpdateList, UpdateSet, UpdateSetNull, UpsertOptions, WithPartition,
 };
 
 use crate::{assets::Asset, events::Event, files::FileMetadata};
@@ -158,45 +158,45 @@ pub struct PatchRelationship {
 }
 
 impl IntoPatch<Patch<PatchRelationship>> for Relationship {
-    fn patch(self, ignore_nulls: bool) -> Patch<PatchRelationship> {
+    fn patch(self, options: &UpsertOptions) -> Patch<PatchRelationship> {
         Patch::<PatchRelationship> {
             id: Identity::ExternalId {
                 external_id: self.external_id,
             },
             update: PatchRelationship {
-                source_type: self.source_type.patch(ignore_nulls),
-                source_external_id: self.source_external_id.patch(ignore_nulls),
-                target_type: self.target_type.patch(ignore_nulls),
-                target_external_id: self.target_external_id.patch(ignore_nulls),
-                confidence: self.confidence.patch(ignore_nulls),
-                start_time: self.start_time.patch(ignore_nulls),
-                end_time: self.end_time.patch(ignore_nulls),
-                data_set_id: self.data_set_id.patch(ignore_nulls),
-                labels: self.labels.patch(ignore_nulls),
+                source_type: self.source_type.patch(options),
+                source_external_id: self.source_external_id.patch(options),
+                target_type: self.target_type.patch(options),
+                target_external_id: self.target_external_id.patch(options),
+                confidence: self.confidence.patch(options),
+                start_time: self.start_time.patch(options),
+                end_time: self.end_time.patch(options),
+                data_set_id: self.data_set_id.patch(options),
+                labels: self.labels.patch(options),
             },
         }
     }
 }
 
 impl IntoPatch<PatchRelationship> for AddRelationship {
-    fn patch(self, ignore_nulls: bool) -> PatchRelationship {
+    fn patch(self, options: &UpsertOptions) -> PatchRelationship {
         PatchRelationship {
-            source_type: self.source_type.patch(ignore_nulls),
-            source_external_id: self.source_external_id.patch(ignore_nulls),
-            target_type: self.target_type.patch(ignore_nulls),
-            target_external_id: self.target_external_id.patch(ignore_nulls),
-            confidence: self.confidence.patch(ignore_nulls),
-            start_time: self.start_time.patch(ignore_nulls),
-            end_time: self.end_time.patch(ignore_nulls),
-            data_set_id: self.data_set_id.patch(ignore_nulls),
-            labels: self.labels.patch(ignore_nulls),
+            source_type: self.source_type.patch(options),
+            source_external_id: self.source_external_id.patch(options),
+            target_type: self.target_type.patch(options),
+            target_external_id: self.target_external_id.patch(options),
+            confidence: self.confidence.patch(options),
+            start_time: self.start_time.patch(options),
+            end_time: self.end_time.patch(options),
+            data_set_id: self.data_set_id.patch(options),
+            labels: self.labels.patch(options),
         }
     }
 }
 
 impl From<Relationship> for Patch<PatchRelationship> {
     fn from(rel: Relationship) -> Self {
-        IntoPatch::<Patch<PatchRelationship>>::patch(rel, false)
+        IntoPatch::<Patch<PatchRelationship>>::patch(rel, &Default::default())
     }
 }
 

--- a/cognite/src/dto/params.rs
+++ b/cognite/src/dto/params.rs
@@ -60,6 +60,7 @@ pub fn to_query_vec_i64(name: &str, item: &Option<Vec<i64>>, params: &mut Vec<(S
 }
 
 /// Simple query with limit and cursor.
+#[derive(Debug, Default, Clone)]
 pub struct LimitCursorQuery {
     /// Maximum number of results to return.
     pub limit: Option<i32>,
@@ -77,6 +78,7 @@ impl IntoParams for LimitCursorQuery {
 }
 
 /// Query with limt, cursor, and partition.
+#[derive(Debug, Default, Clone)]
 pub struct LimitCursorPartitionQuery {
     /// Maximum number of results to return.
     pub limit: Option<i32>,

--- a/cognite/tests/asset_tests.rs
+++ b/cognite/tests/asset_tests.rs
@@ -132,7 +132,10 @@ async fn upsert_assets() {
 
     let res = client
         .assets
-        .upsert(&[new_asset.clone().into()], true)
+        .upsert(
+            &[new_asset.clone().into()],
+            &UpsertOptions::default().ignore_nulls(true),
+        )
         .await
         .unwrap();
     assert_eq!(res[0].description.as_ref().unwrap(), "desc");
@@ -141,7 +144,10 @@ async fn upsert_assets() {
 
     let res = client
         .assets
-        .upsert(&[new_asset.into()], true)
+        .upsert(
+            &[new_asset.into()],
+            &UpsertOptions::default().ignore_nulls(true),
+        )
         .await
         .unwrap();
     assert_eq!(res[0].description.as_ref().unwrap(), "desc 2");

--- a/cognite/tests/event_tests.rs
+++ b/cognite/tests/event_tests.rs
@@ -56,7 +56,10 @@ async fn upsert_events() {
 
     let events = client
         .events
-        .upsert(&[new_event.clone()], true)
+        .upsert(
+            &[new_event.clone()],
+            &UpsertOptions::default().ignore_nulls(true),
+        )
         .await
         .unwrap();
     assert_eq!(1, events.len());
@@ -65,7 +68,10 @@ async fn upsert_events() {
 
     let events = client
         .events
-        .upsert(&[new_event.clone()], true)
+        .upsert(
+            &[new_event.clone()],
+            &UpsertOptions::default().ignore_nulls(true),
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
Makes it so that we use `add` instead of `set` optionally when updating metadata or labels.

This is breaking, but done in such a way that further breaking changes should be unnecessary.