### PR TITLE
Request tracing

### DIFF
--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -1,5 +1,6 @@
 use crate::reqwest::Client;
 use crate::reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware};
+use crate::tracing::{RequestTracer, TracingMiddleware};
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
@@ -362,6 +363,18 @@ impl Builder {
             None => self.custom_middleware = Some(vec![middleware]),
         }
         self
+    }
+
+    /// Add request tracing to the end of the current list of middleware.
+    ///
+    /// # Arguments
+    ///
+    /// * `tracer` - Request tracer.
+    pub fn with_tracing(
+        &mut self,
+        tracer: impl RequestTracer + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.with_custom_middleware(Arc::new(TracingMiddleware::new(tracer)))
     }
 
     /// Create a cognite client. This may fail if not all required parameters are provided.

--- a/cognite/src/lib.rs
+++ b/cognite/src/lib.rs
@@ -8,6 +8,8 @@ mod dto;
 mod error;
 mod retry;
 mod rustls_shim;
+/// Utils for request tracing.
+pub mod tracing;
 
 // Reqwest shim
 use rustls_shim::*;

--- a/cognite/src/tracing.rs
+++ b/cognite/src/tracing.rs
@@ -1,0 +1,51 @@
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use crate::reqwest::{Method, Request, Response, Url};
+use crate::reqwest_middleware::{Middleware, Next, Result};
+use crate::Extensions;
+
+/// Trait for tracing requests going through the SDK.
+pub trait RequestTracer {
+    /// Observe a completed request.
+    fn observe_request(
+        &self,
+        url: Url,
+        method: Method,
+        result: &Result<Response>,
+        duration: Duration,
+    );
+}
+
+/// Middleware for tracing requests sent with the SDK to a custom tracer.
+pub struct TracingMiddleware<T> {
+    tracer: T,
+}
+
+impl<T: RequestTracer> TracingMiddleware<T> {
+    /// Create a new tracing middleware instance with the given tracer.
+    pub fn new(tracer: T) -> Self {
+        Self { tracer }
+    }
+}
+
+#[async_trait]
+impl<T: RequestTracer + Send + Sync + 'static> Middleware for TracingMiddleware<T> {
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        let start = Instant::now();
+        let method = req.method().clone();
+        let url = req.url().clone();
+
+        let result = next.run(req, extensions).await;
+
+        let duration = Instant::now() - start;
+        self.tracer.observe_request(url, method, &result, duration);
+        result
+    }
+}


### PR DESCRIPTION
Simple trait and middleware for tracing requests. This is done generically, to avoid dependencies on specific tracing frameworks in the SDK. Users that want tracing or metrics will have to implement this themselves.