### PR TITLE
Use a feature for integration tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run cargo format
         run: cargo fmt --check
       - name: Test
-        run: cargo test
+        run: cargo test --features=integration_tests
         env:
           COGNITE_PROJECT: opcua-interface-test
           COGNITE_BASE_URL: https://greenfield.cognitedata.com

--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 version = "0.3.0"
 
 [features]
+default = ["rustls-022"]
+integration_tests = []
 rustls-021 = ["reqwest-011", "reqwest-middleware-02", "task-local-extensions"]
 rustls-022 = ["http", "reqwest-012", "reqwest-middleware-03"]
-
-default = ["rustls-022"]
 
 [dependencies]
 async-trait = "^0.1"

--- a/cognite/tests/asset_tests.rs
+++ b/cognite/tests/asset_tests.rs
@@ -1,7 +1,10 @@
+#![cfg(feature = "integration_tests")]
+
+mod common;
+
 #[cfg(test)]
 use cognite::assets::*;
 use cognite::*;
-mod common;
 pub use common::*;
 
 #[tokio::test]

--- a/cognite/tests/data_model_tests.rs
+++ b/cognite/tests/data_model_tests.rs
@@ -1,7 +1,13 @@
-use cognite::models::*;
-use cognite::*;
+#![cfg(feature = "integration_tests")]
+
 mod common;
+
 use cognite::models::spaces::SpaceCreate;
+
+use cognite::models::*;
+
+use cognite::*;
+
 use common::*;
 
 #[tokio::test]

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration_tests")]
+
 #[cfg(test)]
 use cognite::time_series::*;
 use cognite::*;

--- a/cognite/tests/event_tests.rs
+++ b/cognite/tests/event_tests.rs
@@ -1,5 +1,8 @@
+#![cfg(feature = "integration_tests")]
+
 #[cfg(test)]
 mod common;
+
 pub use common::*;
 
 use cognite::events::*;

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration_tests")]
+
 #[cfg(test)]
 use bytes::Bytes;
 use cognite::files::*;

--- a/cognite/tests/time_series_tests.rs
+++ b/cognite/tests/time_series_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration_tests")]
+
 #[cfg(test)]
 mod common;
 pub use common::*;


### PR DESCRIPTION
Tests that contributors might not be setup to run locally now require the feature 'integration-tests' to be set.