### PR TITLE
Update datapoint protos to add instance ID

### DIFF
--- a/cognite/src/api/core/assets.rs
+++ b/cognite/src/api/core/assets.rs
@@ -29,7 +29,7 @@ impl AssetsResource {
     ///
     /// * `asset_ids` - List of IDs or external IDs to retrieve.
     /// * `ignore_unknown_ids` - If `true`, missing assets will be ignored, instead of causing
-    /// the request to fail.
+    ///   the request to fail.
     /// * `aggregated_properties` - List of aggregated properties to include in response.
     pub async fn retrieve(
         &self,

--- a/cognite/src/api/core/files.rs
+++ b/cognite/src/api/core/files.rs
@@ -29,8 +29,8 @@ impl Files {
     /// * `url` - URL to upload stream to.
     /// * `stream` - Stream to upload.
     /// * `stream_chunked` - Set this to `true` to use chunked streaming. Note that this is not supported for the
-    /// azure file backend. If this is set to `false`, the entire file is read into memory before uploading, which may
-    /// be very expensive. Use `upload_stream_known_size` if the size of the file is known.
+    ///   azure file backend. If this is set to `false`, the entire file is read into memory before uploading, which may
+    ///   be very expensive. Use `upload_stream_known_size` if the size of the file is known.
     ///
     /// # Example
     ///
@@ -71,7 +71,7 @@ impl Files {
     /// * `url` - URL to upload stream to.
     /// * `stream` - Stream to upload.
     /// * `size` - Known size of stream in bytes. Note: Do not use this method if the size is not
-    /// actually known!
+    ///   actually known!
     ///
     /// # Example
     ///
@@ -122,7 +122,7 @@ impl Files {
     /// # Arguments
     ///
     /// * `overwrite` - Set this to `true` to overwrite existing files with the same `external_id`.
-    /// If this is `false`, and a file with the given `external_id` already exists, the request will fail.
+    ///   If this is `false`, and a file with the given `external_id` already exists, the request will fail.
     /// * `item` - The file to upload.
     pub async fn upload(&self, overwrite: bool, item: &AddFile) -> Result<FileMetadata> {
         self.api_client

--- a/cognite/src/api/data_organization/relationships.rs
+++ b/cognite/src/api/data_organization/relationships.rs
@@ -26,7 +26,7 @@ impl RelationshipsResource {
     ///
     /// * `relationship_ids` - IDs of relationships to retrieve.
     /// * `ignore_unknown_ids` - Set this to `true` to ignore any IDs not found in CDF.
-    /// If this is `false`, any missing IDs will cause the request to fail.
+    ///   If this is `false`, any missing IDs will cause the request to fail.
     /// * `fetch_resources` - Whether to fetch the associated resources along with the relationship itself.
     pub async fn retrieve(
         &self,

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -417,7 +417,7 @@ where
     ///
     /// * `deletes` - IDs of items to delete.
     /// * `ignore_unknown_ids` - If `true`, missing IDs will be ignored, and not
-    /// cause the request to fail.
+    ///   cause the request to fail.
     fn delete(
         &self,
         deletes: &[TIdt],
@@ -631,7 +631,7 @@ where
     ///
     /// * `ids` - IDs of items to retrieve.
     /// * `ignore_unknown_ids` - If `true`, items missing from CDF will be ignored, and not
-    /// cause the request to fail.
+    ///   cause the request to fail.
     fn retrieve(
         &self,
         ids: &[TIdt],

--- a/cognite/src/api/utils.rs
+++ b/cognite/src/api/utils.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Identity, Result};
+use crate::{Error, FromErrorDetail, Result};
 
 /// Given a result object from CDF, if it is a "conflict" error,
 /// return the list of identities.
@@ -6,14 +6,11 @@ use crate::{Error, Identity, Result};
 /// # Arguments
 ///
 /// * `res` - Result from a CDF request.
-pub fn get_duplicates_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
+pub fn get_duplicates_from_result<T, R: FromErrorDetail>(res: &Result<T>) -> Option<Vec<R>> {
     match res {
         Ok(_) => None,
         Err(e) => match &e {
-            Error::Conflict(c) => c
-                .duplicated
-                .as_ref()
-                .map(|dup| dup.get_identities().collect()),
+            Error::Conflict(c) => c.duplicated.as_ref().map(|dup| dup.get_values().collect()),
             _ => None,
         },
     }
@@ -25,12 +22,12 @@ pub fn get_duplicates_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
 /// # Arguments
 ///
 /// * `res` - Result from a CDF request.
-pub fn get_missing_from_result<T>(res: &Result<T>) -> Option<Vec<Identity>> {
+pub fn get_missing_from_result<T, R: FromErrorDetail>(res: &Result<T>) -> Option<Vec<R>> {
     match res {
         Ok(_) => None,
         Err(e) => match &e {
-            Error::BadRequest(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
-            Error::NotFound(c) => c.missing.as_ref().map(|mis| mis.get_identities().collect()),
+            Error::BadRequest(c) => c.missing.as_ref().map(|mis| mis.get_values().collect()),
+            Error::NotFound(c) => c.missing.as_ref().map(|mis| mis.get_values().collect()),
             _ => None,
         },
     }

--- a/cognite/src/dto/core/datapoint/proto/data_point_insertion_request.proto
+++ b/cognite/src/dto/core/datapoint/proto/data_point_insertion_request.proto
@@ -7,9 +7,10 @@ import "data_points.proto";
 option java_multiple_files = true;
 
 message DataPointInsertionItem {
-    oneof idOrExternalId {
+    oneof timeSeriesReference {
         int64 id = 1;
         string externalId = 2;
+        InstanceId instanceId = 5;
     }
 
     oneof datapointType {

--- a/cognite/src/dto/core/datapoint/proto/data_point_list_response.proto
+++ b/cognite/src/dto/core/datapoint/proto/data_point_list_response.proto
@@ -9,6 +9,7 @@ option java_multiple_files = true;
 message DataPointListItem {
     int64 id = 1;
     string externalId = 2;
+    InstanceId instanceId = 11;
     bool isString = 6;
     bool isStep = 7;
     string unit = 8;

--- a/cognite/src/dto/core/datapoint/proto/data_points.proto
+++ b/cognite/src/dto/core/datapoint/proto/data_points.proto
@@ -54,3 +54,8 @@ message AggregateDatapoint {
 message AggregateDatapoints {
     repeated AggregateDatapoint datapoints = 1;
 }
+
+message InstanceId {
+    string space = 1;
+    string externalId = 2;
+}

--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -80,7 +80,7 @@ pub struct NodeWrite<TProperties> {
     /// then the item will be skipped instead of failing the ingestion request.
     pub existing_version: Option<i32>,
     /// Node type (direct relation).
-    pub r#type: Option<DirectRelationReference>,
+    pub r#type: Option<InstanceId>,
 }
 
 #[skip_serializing_none]
@@ -91,13 +91,13 @@ pub struct EdgeWrite<TProperties> {
     /// Edge space.
     pub space: String,
     /// Edge type (direct relation).
-    pub r#type: DirectRelationReference,
+    pub r#type: InstanceId,
     /// Edge external ID.
     pub external_id: String,
     /// Edge start node.
-    pub start_node: DirectRelationReference,
+    pub start_node: InstanceId,
     /// Edge end node.
-    pub end_node: DirectRelationReference,
+    pub end_node: InstanceId,
     /// List of properties in various containers or views.
     pub sources: Option<Vec<EdgeOrNodeData<TProperties>>>,
     /// Fail the ingestion request if the edge's version is greater than or equal to this value.
@@ -189,7 +189,7 @@ pub struct NodeDefinition<TProperties> {
     /// Node external ID.
     pub external_id: String,
     /// Node type.
-    pub r#type: Option<DirectRelationReference>,
+    pub r#type: Option<InstanceId>,
     /// Time this node was created, in milliseconds since epoch.
     pub created_time: i64,
     /// Time this node was last modified, in milliseconds since epoch.
@@ -210,7 +210,7 @@ pub struct EdgeDefinition<TProperties> {
     /// Edge space.
     pub space: String,
     /// Edge type.
-    pub r#type: DirectRelationReference,
+    pub r#type: InstanceId,
     /// Edge version.
     pub version: String,
     /// Edge external ID.
@@ -220,9 +220,9 @@ pub struct EdgeDefinition<TProperties> {
     /// Time this edge was last modified, in milliseconds since epoch.
     pub last_updated_time: i64,
     /// Edge start node.
-    pub start_node: DirectRelationReference,
+    pub start_node: InstanceId,
     /// Edge end node.
-    pub end_node: DirectRelationReference,
+    pub end_node: InstanceId,
     /// Timestamp when the edge was soft deleted. Note that deleted nodes are
     /// filtered out of query results, but present in sync results.
     /// This means that this value will only be present in sync results.
@@ -234,10 +234,10 @@ pub struct EdgeDefinition<TProperties> {
 /// Shorthand for map from space and view/container external ID to properties object.
 type PropertiesObject<TProperties> = HashMap<String, HashMap<String, TProperties>>;
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// Direct reference to a node.
-pub struct DirectRelationReference {
+pub struct InstanceId {
     /// Node space.
     pub space: String,
     /// Node external ID.

--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    instances::DirectRelationReference,
+    instances::InstanceId,
     query::{QueryDirection, ViewPropertyReference},
 };
 
@@ -208,7 +208,7 @@ pub struct EdgeConnection {
     pub description: Option<String>,
     /// Reference to the node pointed to by the edge type. Consists of a
     /// space and an external ID.
-    pub r#type: DirectRelationReference,
+    pub r#type: InstanceId,
     /// Direction of the connection. Defaults to `outwards`.
     pub direction: Option<QueryDirection>,
     /// Which view this connection references.

--- a/cognite/src/dto/utils.rs
+++ b/cognite/src/dto/utils.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
 use serde::{de::Visitor, Deserialize, Serialize};
+
+use crate::IntegerOrString;
 
 /// Wrapper around an u64 value that can be deserialized from
 /// a string.
@@ -47,4 +51,10 @@ impl<'de> Deserialize<'de> for MaybeStringU64 {
 
         deserializer.deserialize_any(MaybeStringVisitor)
     }
+}
+
+/// Trait implemented for types that can be retrieved from an error detail element.
+pub trait FromErrorDetail: Sized {
+    /// Try to obtain a new instance of self from the detail object.
+    fn from_detail(detail: &HashMap<String, IntegerOrString>) -> Option<Self>;
 }

--- a/cognite/tests/fixtures.rs
+++ b/cognite/tests/fixtures.rs
@@ -3,8 +3,7 @@ use std::collections::HashMap;
 
 use cognite::models::{
     instances::{
-        DirectRelationReference, EdgeOrNodeData, EdgeWrite, NodeOrEdgeCreate,
-        NodeOrEdgeSpecification, NodeWrite,
+        EdgeOrNodeData, EdgeWrite, InstanceId, NodeOrEdgeCreate, NodeOrEdgeSpecification, NodeWrite,
     },
     views::ViewReference,
     ItemId, SourceReference,
@@ -52,17 +51,17 @@ pub fn get_mock_instances(
             .iter()
             .map(|id| {
                 NodeOrEdgeCreate::Edge(EdgeWrite {
-                    r#type: DirectRelationReference {
+                    r#type: InstanceId {
                         space: space.to_owned(),
                         external_id: id.to_string(),
                     },
                     space: space.to_owned(),
                     external_id: id.to_string(),
-                    start_node: DirectRelationReference {
+                    start_node: InstanceId {
                         space: space.to_owned(),
                         external_id: "start_node".to_string(),
                     },
-                    end_node: DirectRelationReference {
+                    end_node: InstanceId {
                         space: space.to_owned(),
                         external_id: "end_node".to_string(),
                     },


### PR DESCRIPTION
This is a little breaking, since it changes some types. `insert_datapoints_create_missing` also won't work with this until we somehow implement the "create missing" part with DMS time series.