### PR TITLE
Implement ser/deser for StatusCode

### DIFF
--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -245,9 +245,9 @@ impl TimeSeriesResource {
         &self,
         items: &[LatestDatapointsQuery],
         ignore_unknown_ids: bool,
-    ) -> Result<Vec<DatapointsResponse>> {
+    ) -> Result<Vec<LatestDatapointsResponse>> {
         let query = Items::new_with_extra_fields(items, IgnoreUnknownIds { ignore_unknown_ids });
-        let datapoints_response: DatapointsListResponse = self
+        let datapoints_response: Items<Vec<LatestDatapointsResponse>> = self
             .api_client
             .post("timeseries/data/latest", &query)
             .await?;


### PR DESCRIPTION
Three major issues:
 - Ser/deser for StatusCode was auto-impld, which didn't make sense for how it was used. Better that we serialize/deserialize to the CDF JSON represenetation.
 - We didn't properly deserialize Infinity and NaN from double values.
 - The untagged enum stuff doesn't work well, there appears to be some bug here, but for latest we actually have sufficient context (using isString) to pick which type to deserialize.