### PR TITLE
Allow setting a default token expiry

### DIFF
--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -138,6 +138,7 @@ impl CogniteClient {
             resource: env_or_none!(COGNITE_RESOURCE),
             audience: env_or_none!(COGNITE_AUDIENCE),
             scopes: env_or_none!(COGNITE_SCOPES),
+            default_expires_in: None,
         };
 
         CogniteClient::new_from_oidc(&api_base_url, auth_config, &project_name, app_name, config)


### PR DESCRIPTION
Technically the OAuth 2.0 RFC doesn't require expires_in to be set, so we should let users specify a fallback expiration time.

This also avoids using systemtime, which is unreliable, and instead uses Instant / Duration, which on many operation systems are based on the monotonic clock instead of system time.