### PR TITLE
feat: update patch to use identity or instance

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,3 +31,4 @@ jobs:
           COGNITE_CLIENT_ID: ${{ secrets.CLIENT_ID }}
           COGNITE_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           CORE_DM_TEST_SPACE: ${{ secrets.CORE_DM_TEST_SPACE }}
+          COGNITE_DATA_SET_EXTERNAL_ID=${{ COGNITE_DATA_SET_EXTERNAL_ID }}

--- a/cognite/examples/instances/main.rs
+++ b/cognite/examples/instances/main.rs
@@ -12,7 +12,13 @@ async fn main() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let col = CogniteExtractorFile::new(space.to_string(), external_id, FileObject::new(None));
+    let col = CogniteExtractorFile::new(
+        space.to_string(),
+        external_id,
+        FileObject {
+            ..Default::default()
+        },
+    );
     let res = client
         .models
         .instances

--- a/cognite/examples/instances/main.rs
+++ b/cognite/examples/instances/main.rs
@@ -12,8 +12,7 @@ async fn main() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
-    let col = CogniteExtractorFile::new(space.to_string(), external_id, FileObject::new(name));
+    let col = CogniteExtractorFile::new(space.to_string(), external_id, FileObject::new(None));
     let res = client
         .models
         .instances

--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -31,7 +31,7 @@ impl Create<AddTimeSeries, TimeSeries> for TimeSeriesResource {}
 impl FilterItems<TimeSeriesFilter, TimeSeries> for TimeSeriesResource {}
 impl FilterWithRequest<TimeSeriesFilterRequest, TimeSeries> for TimeSeriesResource {}
 impl<'a> SearchItems<'a, TimeSeriesFilter, TimeSeriesSearch, TimeSeries> for TimeSeriesResource {}
-impl RetrieveWithIgnoreUnknownIds<Identity, TimeSeries> for TimeSeriesResource {}
+impl RetrieveWithIgnoreUnknownIds<IdentityOrInstance, TimeSeries> for TimeSeriesResource {}
 impl Update<Patch<PatchTimeSeries>, TimeSeries> for TimeSeriesResource {}
 impl DeleteWithIgnoreUnknownIds<Identity> for TimeSeriesResource {}
 

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -9,8 +9,8 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::dto::items::*;
 use crate::{
-    ApiClient, EqIdentity, Filter, Identity, IntoParams, IntoPatch, Partition, Patch, Result,
-    Search, SetCursor, UpsertOptions, WithPartition,
+    ApiClient, EqIdentity, Filter, IdentityOrInstance, IntoParams, IntoPatch, Partition, Patch,
+    Result, Search, SetCursor, UpsertOptions, WithPartition,
 };
 
 use super::utils::{get_duplicates_from_result, get_missing_from_result};
@@ -213,7 +213,7 @@ where
         async move {
             let resp = self.create(creates).await;
 
-            let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
+            let duplicates: Option<Vec<IdentityOrInstance>> = get_duplicates_from_result(&resp);
 
             if let Some(duplicates) = duplicates {
                 let next: Vec<&TCreate> = creates
@@ -284,7 +284,7 @@ where
             let resp: Result<ItemsVec<TResponse>> =
                 self.get_client().post(Self::BASE_PATH, &items).await;
 
-            let duplicates: Option<Vec<Identity>> = get_duplicates_from_result(&resp);
+            let duplicates: Option<Vec<IdentityOrInstance>> = get_duplicates_from_result(&resp);
 
             if let Some(duplicates) = duplicates {
                 let mut to_create = Vec::with_capacity(upserts.len() - duplicates.len());
@@ -520,7 +520,7 @@ where
     {
         async move {
             let response = self.update(updates).await;
-            let missing: Option<Vec<Identity>> = get_missing_from_result(&response);
+            let missing: Option<Vec<IdentityOrInstance>> = get_missing_from_result(&response);
 
             if let Some(missing) = missing {
                 let next: Vec<&TUpdate> = updates

--- a/cognite/src/dto/core/asset.rs
+++ b/cognite/src/dto/core/asset.rs
@@ -5,6 +5,7 @@ pub use self::aggregate::*;
 pub use self::filter::*;
 
 use crate::dto::identity::Identity;
+use crate::IdentityOrInstance;
 use crate::UpsertOptions;
 use crate::{CogniteExternalId, CogniteId, EqIdentity, IntoPatch, IntoPatchItem, UpdateList};
 use crate::{Patch, UpdateMap, UpdateSet, UpdateSetNull};
@@ -165,10 +166,12 @@ impl From<Asset> for AddAsset {
 }
 
 impl EqIdentity for AddAsset {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         match id {
-            Identity::Id { id: _ } => false,
-            Identity::ExternalId { external_id } => self.external_id.as_ref() == Some(external_id),
+            IdentityOrInstance::Identity(Identity::ExternalId { external_id }) => {
+                self.external_id.as_ref() == Some(external_id)
+            }
+            _ => false,
         }
     }
 }

--- a/cognite/src/dto/core/event.rs
+++ b/cognite/src/dto/core/event.rs
@@ -4,6 +4,7 @@ mod filter;
 pub use self::aggregate::*;
 pub use self::filter::*;
 
+use crate::IdentityOrInstance;
 use crate::UpsertOptions;
 use crate::{
     EqIdentity, Identity, IntoPatch, IntoPatchItem, Patch, UpdateList, UpdateMap, UpdateSetNull,
@@ -96,10 +97,12 @@ impl From<Event> for AddEvent {
 }
 
 impl EqIdentity for AddEvent {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         match id {
-            Identity::Id { id: _ } => false,
-            Identity::ExternalId { external_id } => self.external_id.as_ref() == Some(external_id),
+            IdentityOrInstance::Identity(Identity::ExternalId { external_id }) => {
+                self.external_id.as_ref() == Some(external_id)
+            }
+            _ => false,
         }
     }
 }

--- a/cognite/src/dto/core/files/file.rs
+++ b/cognite/src/dto/core/files/file.rs
@@ -138,10 +138,12 @@ impl From<FileMetadata> for AddFile {
 }
 
 impl EqIdentity for AddFile {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         match id {
-            Identity::Id { id: _ } => false,
-            Identity::ExternalId { external_id } => self.external_id.as_ref() == Some(external_id),
+            IdentityOrInstance::Identity(Identity::ExternalId { external_id }) => {
+                self.external_id.as_ref() == Some(external_id)
+            }
+            _ => false,
         }
     }
 }

--- a/cognite/src/dto/core/sequences.rs
+++ b/cognite/src/dto/core/sequences.rs
@@ -1,6 +1,7 @@
 use crate::{
-    AdvancedFilter, EqIdentity, Identity, IntoPatch, IntoPatchItem, Partition, Patch, Range,
-    SetCursor, UpdateList, UpdateMap, UpdateSet, UpdateSetNull, UpsertOptions, WithPartition,
+    AdvancedFilter, EqIdentity, Identity, IdentityOrInstance, IntoPatch, IntoPatchItem, Partition,
+    Patch, Range, SetCursor, UpdateList, UpdateMap, UpdateSet, UpdateSetNull, UpsertOptions,
+    WithPartition,
 };
 
 use serde::{Deserialize, Serialize};
@@ -117,10 +118,12 @@ impl From<Sequence> for AddSequence {
 }
 
 impl EqIdentity for AddSequence {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         match id {
-            Identity::Id { id: _ } => false,
-            Identity::ExternalId { external_id } => self.external_id.as_ref() == Some(external_id),
+            IdentityOrInstance::Identity(Identity::ExternalId { external_id }) => {
+                self.external_id.as_ref() == Some(external_id)
+            }
+            _ => false,
         }
     }
 }

--- a/cognite/src/dto/core/time_series.rs
+++ b/cognite/src/dto/core/time_series.rs
@@ -5,6 +5,7 @@ pub use self::filter::*;
 pub use self::synthetic::*;
 
 use crate::models::instances::CogniteTimeseries;
+use crate::models::instances::InstanceId;
 use crate::IdentityOrInstance;
 use crate::IntoPatch;
 use crate::IntoPatchItem;
@@ -23,6 +24,8 @@ pub struct TimeSeries {
     pub id: i64,
     /// Time series external ID. Must be unique for all time series in the project.
     pub external_id: Option<String>,
+    /// The ID of an instance in Cognite Data Models.
+    pub instance_id: Option<InstanceId>,
     /// Time series name.
     pub name: Option<String>,
     /// Whether this is a time series for string or double data points.

--- a/cognite/src/dto/core/time_series.rs
+++ b/cognite/src/dto/core/time_series.rs
@@ -5,6 +5,7 @@ pub use self::filter::*;
 pub use self::synthetic::*;
 
 use crate::models::instances::CogniteTimeseries;
+use crate::IdentityOrInstance;
 use crate::IntoPatch;
 use crate::IntoPatchItem;
 use crate::UpsertOptions;
@@ -108,10 +109,12 @@ impl From<TimeSeries> for AddTimeSeries {
 }
 
 impl EqIdentity for AddTimeSeries {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         match id {
-            Identity::Id { id: _ } => false,
-            Identity::ExternalId { external_id } => self.external_id.as_ref() == Some(external_id),
+            IdentityOrInstance::Identity(Identity::ExternalId { external_id }) => {
+                self.external_id.as_ref() == Some(external_id)
+            }
+            _ => false,
         }
     }
 }

--- a/cognite/src/dto/data_ingestion/extpipes.rs
+++ b/cognite/src/dto/data_ingestion/extpipes.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
 use crate::{
-    Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateList, UpdateMap, UpdateSet,
-    UpsertOptions,
+    Identity, IdentityOrInstance, IntoPatch, IntoPatchItem, Patch, Range, UpdateList, UpdateMap,
+    UpdateSet, UpsertOptions,
 };
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
@@ -154,9 +154,9 @@ pub struct PatchExtPipe {
 impl IntoPatch<Patch<PatchExtPipe>> for ExtPipe {
     fn patch(self, options: &UpsertOptions) -> Patch<PatchExtPipe> {
         Patch::<PatchExtPipe> {
-            id: Identity::ExternalId {
+            id: IdentityOrInstance::Identity(Identity::ExternalId {
                 external_id: self.external_id,
-            },
+            }),
             update: PatchExtPipe {
                 external_id: None,
                 name: self.name.patch(options),

--- a/cognite/src/dto/data_modeling/instances/extensions/common.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/common.rs
@@ -32,7 +32,7 @@ pub struct CogniteSourceable {
 /// Cognite describable.
 pub struct CogniteDescribable {
     /// Name of the instance.
-    pub name: String,
+    pub name: Option<String>,
     /// Description of the instance.
     pub description: Option<String>,
     /// Text based labels for generic use, limited to 1000.
@@ -43,7 +43,7 @@ pub struct CogniteDescribable {
 
 impl CogniteDescribable {
     /// Create a new describable instance.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: Option<String>) -> Self {
         Self {
             name,
             ..Default::default()

--- a/cognite/src/dto/data_modeling/instances/extensions/files.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/files.rs
@@ -48,16 +48,6 @@ pub struct FileObject {
     pub extracted_data: Option<HashMap<String, String>>,
 }
 
-impl FileObject {
-    /// Create a new file object.
-    pub fn new(name: Option<String>) -> FileObject {
-        Self {
-            description: CogniteDescribable::new(name),
-            ..Default::default()
-        }
-    }
-}
-
 impl From<CogniteExtractorFile> for NodeOrEdgeCreate<FileObject> {
     fn from(value: CogniteExtractorFile) -> NodeOrEdgeCreate<FileObject> {
         value.instance()

--- a/cognite/src/dto/data_modeling/instances/extensions/files.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/files.rs
@@ -50,7 +50,7 @@ pub struct FileObject {
 
 impl FileObject {
     /// Create a new file object.
-    pub fn new(name: String) -> FileObject {
+    pub fn new(name: Option<String>) -> FileObject {
         Self {
             description: CogniteDescribable::new(name),
             ..Default::default()

--- a/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -49,13 +51,17 @@ pub struct Timeseries {
     pub assets: Option<Vec<InstanceId>>,
     /// List of activities associated with this time series.
     pub activities: Option<Vec<InstanceId>>,
+    /// A list of equipment the time series is related to.
+    pub equipment: Option<Vec<InstanceId>>,
     /// Type of datapoints the time series contains.
     pub r#type: TimeSeriesType,
+    /// Unstructured information extracted from source system.
+    pub extracted_data: Option<HashMap<String, String>>,
 }
 
 impl Timeseries {
     /// Create a new timeseries instance.
-    pub fn new(name: String, is_step: bool) -> Self {
+    pub fn new(name: Option<String>, is_step: bool) -> Self {
         Self {
             description: CogniteDescribable::new(name),
             is_step,

--- a/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
@@ -59,17 +59,6 @@ pub struct Timeseries {
     pub extracted_data: Option<HashMap<String, String>>,
 }
 
-impl Timeseries {
-    /// Create a new timeseries instance.
-    pub fn new(name: Option<String>, is_step: bool) -> Self {
-        Self {
-            description: CogniteDescribable::new(name),
-            is_step,
-            ..Default::default()
-        }
-    }
-}
-
 impl From<CogniteTimeseries> for NodeOrEdgeCreate<Timeseries> {
     fn from(value: CogniteTimeseries) -> NodeOrEdgeCreate<Timeseries> {
         value.instance()

--- a/cognite/src/dto/data_modeling/instances/extensions/units.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/units.rs
@@ -29,13 +29,3 @@ pub struct Unit {
     /// Reference to the source of the unit definition.
     pub source_reference: Option<String>,
 }
-
-impl Unit {
-    /// Create a new timeseries instance.
-    pub fn new(name: String) -> Self {
-        Self {
-            description: CogniteDescribable::new(name),
-            ..Default::default()
-        }
-    }
-}

--- a/cognite/src/dto/data_organization/datasets.rs
+++ b/cognite/src/dto/data_organization/datasets.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::IdentityOrInstance;
 use crate::{
     Identity, IntoPatch, IntoPatchItem, Patch, Range, UpdateMap, UpdateSetNull, UpsertOptions,
 };

--- a/cognite/src/dto/data_organization/relationships.rs
+++ b/cognite/src/dto/data_organization/relationships.rs
@@ -5,8 +5,9 @@ use serde_with::skip_serializing_none;
 use crate::sequences::Sequence;
 use crate::time_series::TimeSeries;
 use crate::{
-    CogniteExternalId, Identity, IntoPatch, IntoPatchItem, LabelsFilter, Partition, Patch, Range,
-    SetCursor, UpdateList, UpdateSet, UpdateSetNull, UpsertOptions, WithPartition,
+    CogniteExternalId, Identity, IdentityOrInstance, IntoPatch, IntoPatchItem, LabelsFilter,
+    Partition, Patch, Range, SetCursor, UpdateList, UpdateSet, UpdateSetNull, UpsertOptions,
+    WithPartition,
 };
 
 use crate::{assets::Asset, events::Event, files::FileMetadata};
@@ -160,9 +161,9 @@ pub struct PatchRelationship {
 impl IntoPatch<Patch<PatchRelationship>> for Relationship {
     fn patch(self, options: &UpsertOptions) -> Patch<PatchRelationship> {
         Patch::<PatchRelationship> {
-            id: Identity::ExternalId {
+            id: IdentityOrInstance::Identity(Identity::ExternalId {
                 external_id: self.external_id,
-            },
+            }),
             update: PatchRelationship {
                 source_type: self.source_type.patch(options),
                 source_external_id: self.source_external_id.patch(options),

--- a/cognite/src/dto/identity.rs
+++ b/cognite/src/dto/identity.rs
@@ -141,7 +141,7 @@ impl FromErrorDetail for CogniteExternalId {
 /// Trait indicating that a type can be compared to an identity.
 pub trait EqIdentity {
     /// Return true if the identity given by `id` points to self.
-    fn eq(&self, id: &Identity) -> bool;
+    fn eq(&self, id: &IdentityOrInstance) -> bool;
 }
 
 impl From<String> for CogniteExternalId {
@@ -168,6 +168,12 @@ pub enum IdentityOrInstance {
         /// Instance id.
         instance_id: InstanceId,
     },
+}
+
+impl Default for IdentityOrInstance {
+    fn default() -> Self {
+        IdentityOrInstance::Identity(Default::default())
+    }
 }
 
 impl FromErrorDetail for IdentityOrInstance {

--- a/cognite/src/dto/patch_item.rs
+++ b/cognite/src/dto/patch_item.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{EqIdentity, Identity};
+use crate::{EqIdentity, IdentityOrInstance};
 
 /// Options for performing automatic upserts.
 #[derive(Clone, Copy, Debug, Default)]
@@ -330,7 +330,7 @@ where
 {
     #[serde(flatten)]
     /// Identity of resource to update.
-    pub id: Identity,
+    pub id: IdentityOrInstance,
     /// Resource patch.
     pub update: T,
 }
@@ -344,7 +344,7 @@ where
     /// # Arguments
     ///
     /// * `id` - Identity of resource to update.
-    pub fn new(id: Identity) -> Self {
+    pub fn new(id: IdentityOrInstance) -> Self {
         Patch::<T> {
             id,
             update: T::default(),
@@ -356,7 +356,7 @@ impl<T> EqIdentity for Patch<T>
 where
     T: Default,
 {
-    fn eq(&self, id: &Identity) -> bool {
+    fn eq(&self, id: &IdentityOrInstance) -> bool {
         &self.id == id
     }
 }
@@ -365,14 +365,16 @@ where
 macro_rules! to_idt {
     ($it:ident) => {
         if $it.id > 0 {
-            Identity::Id { id: $it.id }
+            IdentityOrInstance::Identity(Identity::Id { id: $it.id })
         } else {
             $it.external_id
                 .as_ref()
-                .map(|e| Identity::ExternalId {
-                    external_id: e.clone(),
+                .map(|e| {
+                    IdentityOrInstance::Identity(Identity::ExternalId {
+                        external_id: e.clone(),
+                    })
                 })
-                .unwrap_or_else(|| Identity::Id { id: $it.id })
+                .unwrap_or_else(|| IdentityOrInstance::Identity(Identity::Id { id: $it.id }))
         }
     };
 }

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -61,11 +61,10 @@ async fn create_and_delete_file_instance() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(None),
     );
     let res = client
         .models
@@ -124,12 +123,11 @@ async fn create_and_delete_timeseries_instance() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
 
     let timeseries = CogniteTimeseries::new(
         space.to_string(),
         external_id.to_string(),
-        Timeseries::new(name.to_string(), false),
+        Timeseries::new(None, false),
     );
     let timeseries_res = client
         .models

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -64,7 +64,9 @@ async fn create_and_delete_file_instance() {
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(None),
+        FileObject {
+            ..Default::default()
+        },
     );
     let res = client
         .models
@@ -127,7 +129,9 @@ async fn create_and_delete_timeseries_instance() {
     let timeseries = CogniteTimeseries::new(
         space.to_string(),
         external_id.to_string(),
-        Timeseries::new(None, false),
+        Timeseries {
+            ..Default::default()
+        },
     );
     let timeseries_res = client
         .models

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -213,11 +213,10 @@ async fn create_delete_dm_files() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(None),
     );
     let res = client
         .models
@@ -287,11 +286,10 @@ async fn create_core_dm_multipart_file() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(None),
     );
     let res = client
         .models

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -216,7 +216,9 @@ async fn create_delete_dm_files() {
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(None),
+        FileObject {
+            ..Default::default()
+        },
     );
     let res = client
         .models
@@ -289,7 +291,9 @@ async fn create_core_dm_multipart_file() {
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(None),
+        FileObject {
+            ..Default::default()
+        },
     );
     let res = client
         .models

--- a/cognite/tests/time_series_tests.rs
+++ b/cognite/tests/time_series_tests.rs
@@ -91,7 +91,7 @@ async fn create_and_delete_missing() {
                         let mut timeseries = CogniteTimeseries::new(
                             instance_id.space.to_string(),
                             instance_id.external_id.to_string(),
-                            Timeseries::new(uuid::Uuid::new_v4().to_string(), false),
+                            Timeseries::new(None, false),
                         );
                         timeseries.properties.r#type = TimeSeriesType::String;
                         AddDmOrTimeSeries::Cdm(Box::new(timeseries))


### PR DESCRIPTION
This change is necessitated by the fact that `data_set_id` can only be set using the timeseries API. This can't be set when created in core DM. 
A lot of the file changes resulted from updating `Patch<>` type to use `IdentityOrInstance` instead of `Identity`.