### PR TITLE
clean up of optional values

### DIFF
--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 edition = "2021"
 name = "cognite"
 publish = false
-version = "0.4.0"
+version = "0.4.1"
 
 [features]
 default = ["rustls-022"]

--- a/cognite/examples/instances/main.rs
+++ b/cognite/examples/instances/main.rs
@@ -12,8 +12,7 @@ async fn main() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
-    let col = CogniteExtractorFile::new(space.to_string(), external_id, FileObject::new(name));
+    let col = CogniteExtractorFile::new(space.to_string(), external_id, FileObject::new());
     let res = client
         .models
         .instances

--- a/cognite/src/dto/data_modeling/instances/extensions/common.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/common.rs
@@ -32,7 +32,7 @@ pub struct CogniteSourceable {
 /// Cognite describable.
 pub struct CogniteDescribable {
     /// Name of the instance.
-    pub name: String,
+    pub name: Option<String>,
     /// Description of the instance.
     pub description: Option<String>,
     /// Text based labels for generic use, limited to 1000.
@@ -43,9 +43,8 @@ pub struct CogniteDescribable {
 
 impl CogniteDescribable {
     /// Create a new describable instance.
-    pub fn new(name: String) -> Self {
+    pub fn new() -> Self {
         Self {
-            name,
             ..Default::default()
         }
     }

--- a/cognite/src/dto/data_modeling/instances/extensions/files.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/files.rs
@@ -50,9 +50,8 @@ pub struct FileObject {
 
 impl FileObject {
     /// Create a new file object.
-    pub fn new(name: String) -> FileObject {
+    pub fn new() -> FileObject {
         Self {
-            description: CogniteDescribable::new(name),
             ..Default::default()
         }
     }

--- a/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
@@ -55,9 +55,8 @@ pub struct Timeseries {
 
 impl Timeseries {
     /// Create a new timeseries instance.
-    pub fn new(name: String, is_step: bool) -> Self {
+    pub fn new(is_step: bool) -> Self {
         Self {
-            description: CogniteDescribable::new(name),
             is_step,
             ..Default::default()
         }

--- a/cognite/src/dto/data_modeling/instances/extensions/units.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/units.rs
@@ -29,13 +29,3 @@ pub struct Unit {
     /// Reference to the source of the unit definition.
     pub source_reference: Option<String>,
 }
-
-impl Unit {
-    /// Create a new timeseries instance.
-    pub fn new(name: String) -> Self {
-        Self {
-            description: CogniteDescribable::new(name),
-            ..Default::default()
-        }
-    }
-}

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -61,11 +61,10 @@ async fn create_and_delete_file_instance() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(),
     );
     let res = client
         .models
@@ -124,12 +123,11 @@ async fn create_and_delete_timeseries_instance() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
 
     let timeseries = CogniteTimeseries::new(
         space.to_string(),
         external_id.to_string(),
-        Timeseries::new(name.to_string(), false),
+        Timeseries::new(false),
     );
     let timeseries_res = client
         .models

--- a/cognite/tests/file_tests.rs
+++ b/cognite/tests/file_tests.rs
@@ -213,11 +213,10 @@ async fn create_delete_dm_files() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(),
     );
     let res = client
         .models
@@ -287,11 +286,10 @@ async fn create_core_dm_multipart_file() {
     let client = CogniteClient::new_oidc("testing_instances", None).unwrap();
     let external_id = Uuid::new_v4().to_string();
     let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
-    let name = "random".to_string();
     let col = CogniteExtractorFile::new(
         space.to_string(),
         external_id.to_string(),
-        FileObject::new(name),
+        FileObject::new(),
     );
     let res = client
         .models

--- a/cognite/tests/time_series_tests.rs
+++ b/cognite/tests/time_series_tests.rs
@@ -91,7 +91,7 @@ async fn create_and_delete_missing() {
                         let mut timeseries = CogniteTimeseries::new(
                             instance_id.space.to_string(),
                             instance_id.external_id.to_string(),
-                            Timeseries::new(uuid::Uuid::new_v4().to_string(), false),
+                            Timeseries::new(false),
                         );
                         timeseries.properties.r#type = TimeSeriesType::String;
                         AddDmOrTimeSeries::Cdm(Box::new(timeseries))


### PR DESCRIPTION
It turns out that the name in `CogniteDescribable` is also optional.