### PR TITLE
Add instance ID to a few timeseries methods

### DIFF
--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -32,6 +32,7 @@ impl FilterItems<TimeSeriesFilter, TimeSeries> for TimeSeriesResource {}
 impl FilterWithRequest<TimeSeriesFilterRequest, TimeSeries> for TimeSeriesResource {}
 impl<'a> SearchItems<'a, TimeSeriesFilter, TimeSeriesSearch, TimeSeries> for TimeSeriesResource {}
 impl RetrieveWithIgnoreUnknownIds<Identity, TimeSeries> for TimeSeriesResource {}
+impl RetrieveWithIgnoreUnknownIds<IdentityOrInstance, TimeSeries> for TimeSeriesResource {}
 impl Update<Patch<PatchTimeSeries>, TimeSeries> for TimeSeriesResource {}
 impl DeleteWithIgnoreUnknownIds<Identity> for TimeSeriesResource {}
 

--- a/cognite/src/dto/core/datapoint/filter.rs
+++ b/cognite/src/dto/core/datapoint/filter.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::Identity;
+use crate::{Identity, IdentityOrInstance};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -123,7 +123,7 @@ pub struct DatapointsFilter {
 pub struct DatapointsQuery {
     #[serde(flatten)]
     /// ID or external ID of time series to retrieve data from.
-    pub id: Identity,
+    pub id: IdentityOrInstance,
     /// Get datapoints from, and including, this time.
     pub start: Option<TimestampOrRelative>,
     /// Get datapoints up to, but excluding, this point in time.
@@ -246,7 +246,7 @@ pub struct DeleteDatapointsQuery {
     pub exclusive_end: i64,
     #[serde(rename = "id", flatten)]
     /// ID or external ID of time series to retrieve data from.
-    pub id: Identity,
+    pub id: IdentityOrInstance,
 }
 
 impl DeleteDatapointsQuery {
@@ -257,9 +257,13 @@ impl DeleteDatapointsQuery {
     /// * `id` - ID or external ID of time series to delete from.
     /// * `inclusive_begin` - Inclusive start time, in milliseconds since epoch.
     /// * `exclusive_end` - Exclusive end time, in milliseconds since epoch.
-    pub fn new(id: Identity, inclusive_begin: i64, exclusive_end: i64) -> DeleteDatapointsQuery {
+    pub fn new(
+        id: impl Into<IdentityOrInstance>,
+        inclusive_begin: i64,
+        exclusive_end: i64,
+    ) -> DeleteDatapointsQuery {
         DeleteDatapointsQuery {
-            id,
+            id: id.into(),
             inclusive_begin,
             exclusive_end,
         }

--- a/cognite/src/dto/core/time_series.rs
+++ b/cognite/src/dto/core/time_series.rs
@@ -5,6 +5,7 @@ pub use self::filter::*;
 pub use self::synthetic::*;
 
 use crate::models::instances::CogniteTimeseries;
+use crate::models::instances::InstanceId;
 use crate::IntoPatch;
 use crate::IntoPatchItem;
 use crate::UpsertOptions;
@@ -22,6 +23,9 @@ pub struct TimeSeries {
     pub id: i64,
     /// Time series external ID. Must be unique for all time series in the project.
     pub external_id: Option<String>,
+    /// Time series ID in data models. Only present if this time series was created through
+    /// data modeling.
+    pub instance_id: Option<InstanceId>,
     /// Time series name.
     pub name: Option<String>,
     /// Whether this is a time series for string or double data points.

--- a/cognite/src/dto/identity.rs
+++ b/cognite/src/dto/identity.rs
@@ -170,6 +170,118 @@ pub enum IdentityOrInstance {
     },
 }
 
+impl IdentityOrInstance {
+    /// Create a new IdentityOrInstance using an internal ID.
+    pub fn id(id: i64) -> Self {
+        Self::Identity(Identity::id(id))
+    }
+
+    /// Create a new IdentityOrInstance using an external ID.
+    pub fn external_id(external_id: impl Into<String>) -> Self {
+        Self::Identity(Identity::external_id(external_id))
+    }
+
+    /// Create a new IdentityOrInstance using an instance ID.
+    pub fn instance_id(instance_id: impl Into<InstanceId>) -> Self {
+        Self::InstanceId {
+            instance_id: instance_id.into(),
+        }
+    }
+
+    /// Get self as internal ID.
+    pub fn as_id(&self) -> Option<i64> {
+        match self {
+            Self::Identity(i) => i.as_id(),
+            _ => None,
+        }
+    }
+
+    /// Get self as external ID.
+    pub fn as_external_id(&self) -> Option<&String> {
+        match self {
+            Self::Identity(i) => i.as_external_id(),
+            _ => None,
+        }
+    }
+
+    /// Get self as identity.
+    pub fn as_identity(&self) -> Option<&Identity> {
+        match self {
+            Self::Identity(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Get self as instance id.
+    pub fn as_instance_id(&self) -> Option<&InstanceId> {
+        match self {
+            Self::InstanceId { instance_id: i } => Some(i),
+            _ => None,
+        }
+    }
+}
+
+// Default impl is not super meaningful, but is useful in some cases
+impl Default for IdentityOrInstance {
+    fn default() -> Self {
+        Self::Identity(Default::default())
+    }
+}
+
+impl From<&str> for IdentityOrInstance {
+    fn from(value: &str) -> Self {
+        Self::Identity(Identity::from(value))
+    }
+}
+
+impl From<String> for IdentityOrInstance {
+    fn from(value: String) -> Self {
+        Self::Identity(Identity::from(value))
+    }
+}
+
+impl From<i64> for IdentityOrInstance {
+    fn from(value: i64) -> Self {
+        Self::Identity(Identity::from(value))
+    }
+}
+
+impl From<Identity> for IdentityOrInstance {
+    fn from(value: Identity) -> Self {
+        Self::Identity(value)
+    }
+}
+
+impl From<InstanceId> for IdentityOrInstance {
+    fn from(value: InstanceId) -> Self {
+        Self::InstanceId { instance_id: value }
+    }
+}
+
+impl PartialEq<i64> for IdentityOrInstance {
+    fn eq(&self, other: &i64) -> bool {
+        self.as_id().as_ref() == Some(other)
+    }
+}
+
+impl PartialEq<str> for IdentityOrInstance {
+    fn eq(&self, other: &str) -> bool {
+        self.as_external_id().map(|a| a.as_str()) == Some(other)
+    }
+}
+
+impl PartialEq<InstanceId> for IdentityOrInstance {
+    fn eq(&self, other: &InstanceId) -> bool {
+        self.as_instance_id() == Some(other)
+    }
+}
+
+impl PartialEq<Identity> for IdentityOrInstance {
+    fn eq(&self, other: &Identity) -> bool {
+        self.as_identity() == Some(other)
+    }
+}
+
 impl FromErrorDetail for IdentityOrInstance {
     fn from_detail(detail: &HashMap<String, Box<IntegerStringOrObject>>) -> Option<Self> {
         if let Some(object) = ApiErrorDetail::get_object(detail, "instanceId") {

--- a/cognite/src/dto/params.rs
+++ b/cognite/src/dto/params.rs
@@ -19,16 +19,15 @@ pub fn to_query<T>(name: &str, item: &Option<T>, params: &mut Vec<(String, Strin
 where
     T: Display,
 {
-    match item {
-        Some(it) => params.push((name.to_string(), it.to_string())),
-        None => (),
+    if let Some(it) = item {
+        params.push((name.to_string(), it.to_string()));
     }
 }
 
 /// Push a list of items to the query with name `name` if `item` is `Some`.
 pub fn to_query_vec(name: &str, item: &Option<Vec<String>>, params: &mut Vec<(String, String)>) {
-    match item {
-        Some(it) => params.push((
+    if let Some(it) = item {
+        params.push((
             name.to_string(),
             format!(
                 "[{}]",
@@ -37,15 +36,14 @@ pub fn to_query_vec(name: &str, item: &Option<Vec<String>>, params: &mut Vec<(St
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
-        )),
-        None => (),
+        ));
     }
 }
 
 /// Push a list of numbers to the query with name `name` if `item` is `Some`.
 pub fn to_query_vec_i64(name: &str, item: &Option<Vec<i64>>, params: &mut Vec<(String, String)>) {
-    match item {
-        Some(it) => params.push((
+    if let Some(it) = item {
+        params.push((
             name.to_string(),
             format!(
                 "[{}]",
@@ -54,8 +52,7 @@ pub fn to_query_vec_i64(name: &str, item: &Option<Vec<i64>>, params: &mut Vec<(S
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
-        )),
-        None => (),
+        ))
     }
 }
 

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -49,7 +49,7 @@ async fn create_retrieve_delete_double_datapoints() {
     client
         .time_series
         .insert_datapoints(vec![AddDatapoints {
-            id: IdentityOrInstance::Identity(Identity::Id { id: ts.id }),
+            id: ts.id.into(),
             datapoints: DatapointsEnumType::NumericDatapoints(
                 (0..100)
                     .map(|i| DatapointDouble {
@@ -68,7 +68,7 @@ async fn create_retrieve_delete_double_datapoints() {
         .time_series
         .retrieve_datapoints(DatapointsFilter {
             items: vec![DatapointsQuery {
-                id: Identity::Id { id: ts.id },
+                id: ts.id.into(),
                 ..Default::default()
             }],
             start: Some((start + 5000).into()),
@@ -89,7 +89,7 @@ async fn create_retrieve_delete_double_datapoints() {
         .delete_datapoints(&[DeleteDatapointsQuery {
             inclusive_begin: start,
             exclusive_end: start + 50000,
-            id: Identity::Id { id: ts.id },
+            id: ts.id.into(),
         }])
         .await
         .unwrap();
@@ -99,7 +99,7 @@ async fn create_retrieve_delete_double_datapoints() {
         .time_series
         .retrieve_datapoints(DatapointsFilter {
             items: vec![DatapointsQuery {
-                id: Identity::Id { id: ts.id },
+                id: ts.id.into(),
                 ..Default::default()
             }],
             start: Some((start + 5000).into()),
@@ -152,7 +152,7 @@ async fn create_retrieve_delete_string_datapoints() {
         .time_series
         .retrieve_datapoints(DatapointsFilter {
             items: vec![DatapointsQuery {
-                id: Identity::Id { id: ts.id },
+                id: ts.id.into(),
                 ..Default::default()
             }],
             start: Some((start + 5000).into()),
@@ -173,7 +173,7 @@ async fn create_retrieve_delete_string_datapoints() {
         .delete_datapoints(&[DeleteDatapointsQuery {
             inclusive_begin: start,
             exclusive_end: start + 50000,
-            id: Identity::Id { id: ts.id },
+            id: ts.id.into(),
         }])
         .await
         .unwrap();
@@ -183,7 +183,7 @@ async fn create_retrieve_delete_string_datapoints() {
         .time_series
         .retrieve_datapoints(DatapointsFilter {
             items: vec![DatapointsQuery {
-                id: Identity::Id { id: ts.id },
+                id: ts.id.into(),
                 ..Default::default()
             }],
             start: Some((start + 5000).into()),
@@ -300,7 +300,7 @@ async fn create_retrieve_double_datapoints_with_status() {
         .time_series
         .retrieve_datapoints(DatapointsFilter {
             items: vec![DatapointsQuery {
-                id: Identity::from(ts.id),
+                id: ts.id.into(),
                 include_status: Some(true),
                 ignore_bad_data_points: Some(false),
                 ..Default::default()


### PR DESCRIPTION
Also improve ergonomics of the IdentityOrInstance type. From and PartialEq impls can really make a type easier to use, and is worthwhile for a core type such as this.