### PR TITLE
Make error in authenticator a little clearer

### DIFF
--- a/cognite/src/api/authenticator.rs
+++ b/cognite/src/api/authenticator.rs
@@ -263,7 +263,7 @@ impl Authenticator {
 
         let response: AuthenticatorResponse = serde_json::from_str(&response).map_err(|e| {
             AuthenticatorError::internal_error(
-                "Failed to deserialize".to_string(),
+                "Failed to deserialize response from OAuth endpoint".to_string(),
                 Some(e.to_string()),
             )
         })?;

--- a/cognite/src/auth.rs
+++ b/cognite/src/auth.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use http::Extensions;
 use reqwest::{Request, Response};
@@ -49,7 +50,8 @@ impl Middleware for AuthenticatorMiddleware {
                 self.authenticator
                     .set_headers(req.headers_mut(), client)
                     .await
-                    .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))?;
+                    .map_err(|e| reqwest_middleware::Error::Middleware(e.into()))
+                    .context("Failed to authenticate request")?;
             }
             // Once we're done, remove the flag
             extensions.remove::<AuthenticatorFlag>();

--- a/cognite/src/dto/core/datapoint/status_code.rs
+++ b/cognite/src/dto/core/datapoint/status_code.rs
@@ -119,7 +119,7 @@ impl StatusCode {
     /// Set the info type, this will clear the info bits if set to NotUsed.
     #[must_use = "Status code is copied, not modified in place."]
     pub fn set_info_type(mut self, value: StatusCodeInfoType) -> Self {
-        self.0 = self.0 & !(1 << 10) | ((value as u32) & 1) << 10;
+        self.0 = self.0 & !(1 << 10) | (((value as u32) & 1) << 10);
         // Clear the info bits if we are setting info type to not used.
         if matches!(value, StatusCodeInfoType::NotUsed) {
             self.0 &= !INFO_BITS_MASK;


### PR DESCRIPTION
There isn't a ton we can do to make it obvious what went wrong, since we can't really log the response from an OAuth request, but we can at least make it obvious that the error came from the authenticator. Currently you'll just get "Error in middleware: Failed to deserialize" which is less helpful.