### PR TITLE
Correcting dto for data modeling aggregation response

### DIFF
--- a/cognite/src/dto/data_modeling/instances.rs
+++ b/cognite/src/dto/data_modeling/instances.rs
@@ -493,7 +493,7 @@ pub struct HistogramBucket {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", untagged)]
 /// Result item in instances aggregate response.
 pub enum AggregateResult {
     /// Result of average aggregate.

--- a/cognite/tests/fixtures.rs
+++ b/cognite/tests/fixtures.rs
@@ -9,6 +9,60 @@ use cognite::models::{
     ItemId, SourceReference,
 };
 
+pub fn get_instances_aggregate_request() -> String {
+    format!(
+        r#"
+            {{
+              "aggregates": [
+                {{ "histogram": {{ "property": "property_1", "interval": 1.0 }} }}
+              ],
+              "groupBy": ["property_to_group_by"],
+              "filter": {{
+                "hasData": [
+                  {{ "type": "container", "space": "space_1", "externalId": "container_1" }}
+                ]
+              }},
+              "instanceType": "node",
+              "view": {{
+                "type": "view",
+                "space": "space_1",
+                "externalId": "view_1",
+                "version": "1"
+              }}
+            }}
+        "#
+    )
+}
+
+pub fn get_instances_aggregate_response() -> String {
+    format!(
+        r#"
+        {{
+          "items": [
+            {{
+              "instanceType": "node",
+              "aggregates": [
+                {{
+                  "aggregate": "histogram",
+                  "interval": 1.0,
+                  "property": "head",
+                  "buckets": [
+                    {{
+                      "start": 0,
+                      "count": 1
+                    }}
+                  ]
+                }}
+              ],
+              "group": {{
+                "industry": "industry_1"
+              }}
+            }}]
+        }}
+        "#
+    )
+}
+
 fn get_mock_properties() -> HashMap<String, String> {
     let mut properties = std::collections::HashMap::new();
     properties.insert("key1".to_string(), "value1".to_string());


### PR DESCRIPTION
Currently .models.instances.aggregate() fails when deserializing the API response
`kind: Decode, source: Error("unknown variant `aggregate`, expected one of `avg`, `min`, `max`, `count`, `sum`, `histogram``

Adding the serde untagged attribute to `enum AggregateResult` seems to fix it, and I hope this okay @einarmo 