### PR TITLE
Add some missing properties to views and containers

### DIFF
--- a/cognite/src/dto/data_modeling/common.rs
+++ b/cognite/src/dto/data_modeling/common.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -35,6 +37,16 @@ pub enum SourceReference {
     View(ViewReference),
     /// A container.
     Container(ItemId),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase", tag = "type")]
+/// A reference to a property in a source view or container.
+pub struct SourcePropertyReference {
+    /// ID of the view or container.
+    pub source: SourceReference,
+    /// Identifier of the property in the source.
+    pub identifier: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -106,6 +118,28 @@ pub struct PrimitiveProperty {
     #[derivative(Default(value = "false"))]
     /// Whether this is a list or not.
     pub list: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+/// Description of an enum value in an enum property.
+pub struct EnumValueDescription {
+    /// Name of the enum value.
+    pub name: String,
+    /// Enum value description.
+    pub description: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+/// Description of an enum property.
+pub struct EnumProperty {
+    /// The value to use when the enum value is unknown.
+    pub unknown_value: Option<String>,
+    /// Map from enum value identifier to description.
+    pub values: HashMap<String, EnumValueDescription>,
 }
 
 #[skip_serializing_none]

--- a/cognite/src/dto/data_modeling/common.rs
+++ b/cognite/src/dto/data_modeling/common.rs
@@ -126,7 +126,7 @@ pub struct PrimitiveProperty {
 /// Description of an enum value in an enum property.
 pub struct EnumValueDescription {
     /// Name of the enum value.
-    pub name: String,
+    pub name: Option<String>,
     /// Enum value description.
     pub description: Option<String>,
 }

--- a/cognite/src/dto/data_modeling/containers.rs
+++ b/cognite/src/dto/data_modeling/containers.rs
@@ -8,7 +8,7 @@ use crate::{
     to_query, IntoParams, RawValue, SetCursor,
 };
 
-use super::common::{CDFExternalIdReference, PrimitiveProperty, TextProperty};
+use super::common::{CDFExternalIdReference, EnumProperty, PrimitiveProperty, TextProperty};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase", tag = "type")]
@@ -40,6 +40,8 @@ pub enum ContainerPropertyType {
     Sequence(CDFExternalIdReference),
     /// Node reference property.
     Direct(DirectNodeRelationType),
+    /// Enum property.
+    Enum(EnumProperty),
 }
 
 #[skip_serializing_none]

--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 
 use super::{
+    common::{EnumProperty, SourcePropertyReference},
     instances::InstanceId,
-    query::{QueryDirection, ViewPropertyReference},
+    query::QueryDirection,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
@@ -229,7 +230,9 @@ pub struct ReverseDirectRelationConnection {
     /// Which view this connection references.
     pub source: TaggedViewReference,
     /// Which property this connection uses.
-    pub through: ViewPropertyReference,
+    pub through: SourcePropertyReference,
+    /// Whether this relation targets a list of direct relations.
+    pub targets_list: bool,
 }
 
 #[skip_serializing_none]
@@ -313,6 +316,9 @@ pub struct ViewCorePropertyDefinition {
     pub container: TaggedContainerReference,
     /// Unique identifier within the referenced container.
     pub container_property_identifier: String,
+    #[serde(default)]
+    /// Whether this property is immutable.
+    pub immutable: bool,
 }
 
 #[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
@@ -345,6 +351,8 @@ pub enum ViewCorePropertyType {
     Sequence(CDFExternalIdReference),
     /// Direct relation to a node.
     Direct(ViewDirectNodeRelation),
+    /// Enum property.
+    Enum(EnumProperty),
 }
 
 #[skip_serializing_none]

--- a/cognite/tests/views_tests.rs
+++ b/cognite/tests/views_tests.rs
@@ -152,7 +152,10 @@ async fn test_retrieve_complex_view() {
     assert_eq!(prop.name, Some("Type".to_string()));
     assert!(prop.immutable);
     let ty = assert_is!(&prop.r#type, ViewCorePropertyType::Enum(v), v);
-    assert_eq!(ty.values.get("string").unwrap().name, "string");
+    assert_eq!(
+        ty.values.get("string").unwrap().name.as_ref().unwrap(),
+        "string"
+    );
 
     // Check that a reverse direct relation looks good.'
     let prop = assert_is!(

--- a/cognite/tests/views_tests.rs
+++ b/cognite/tests/views_tests.rs
@@ -2,7 +2,9 @@
 use cognite::models::*;
 use cognite::*;
 
-use cognite::models::views::{ViewQuery, ViewReference};
+use cognite::models::views::{
+    ConnectionDefinition, ViewCorePropertyType, ViewDefinitionProperties, ViewQuery, ViewReference,
+};
 use wiremock::matchers::{body_json_string, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -113,4 +115,53 @@ async fn delete_views() {
     assert_eq!(result.external_id, "MyView".to_string());
     assert_eq!(result.space, "MySpace".to_string());
     assert_eq!(result.version, "1".to_string());
+}
+
+macro_rules! assert_is {
+    ($v:expr, $p:pat, $k:ident) => {
+        match $v {
+            $p => $k,
+            _ => panic!("Expected {} but got {:?}", stringify!($p), $v),
+        }
+    };
+}
+
+#[tokio::test]
+async fn test_retrieve_complex_view() {
+    let client = get_client();
+
+    let time_series = client
+        .models
+        .views
+        .retrieve(&[ItemIdOptionalVersion {
+            space: "cdf_cdm".to_owned(),
+            external_id: "CogniteTimeSeries".to_owned(),
+            version: None,
+        }])
+        .await
+        .unwrap();
+    assert_eq!(1, time_series.len());
+
+    let view = time_series.into_iter().next().unwrap();
+    // Check that the enum property looks good
+    let prop = assert_is!(
+        view.properties.get("type"),
+        Some(ViewDefinitionProperties::ViewCorePropertyDefinition(v)),
+        v
+    );
+    assert_eq!(prop.name, Some("Type".to_string()));
+    assert!(prop.immutable);
+    let ty = assert_is!(&prop.r#type, ViewCorePropertyType::Enum(v), v);
+    assert_eq!(ty.values.get("string").unwrap().name, "string");
+
+    // Check that a reverse direct relation looks good.'
+    let prop = assert_is!(
+        view.properties.get("activities"),
+        Some(ViewDefinitionProperties::ConnectionDefinition(
+            ConnectionDefinition::MultiReverseDirectRelation(c),
+        )),
+        c
+    );
+    assert_eq!(prop.name, Some("Activities".to_string()));
+    assert!(prop.targets_list);
 }


### PR DESCRIPTION
There have been changes to the API, and there was an issue on reverse direct relation properties that somehow slipped by. I've added a test that retrieves a complex view.