### PR TITLE
Add support for data modeling streams

### DIFF
--- a/cognite/src/api/api_client.rs
+++ b/cognite/src/api/api_client.rs
@@ -18,6 +18,7 @@ pub struct ApiClient {
     api_base_url: String,
     app_name: String,
     client: ClientWithMiddleware,
+    api_version: Option<String>,
 }
 
 impl ApiClient {
@@ -33,6 +34,24 @@ impl ApiClient {
             api_base_url: String::from(api_base_url),
             app_name: String::from(app_name),
             client,
+            api_version: None,
+        }
+    }
+
+    /// Create a new api client with a custom API version.
+    /// This will set the `cdf-version` header to the given value.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_version` - API version to use.
+    pub fn clone_with_api_version(&self, api_version: &str) -> ApiClient {
+        // We do clone the base URL here, but note that the client is internally
+        // cloneable, so we do still share it cross resources, which is important.
+        ApiClient {
+            api_base_url: self.api_base_url.clone(),
+            app_name: self.app_name.clone(),
+            client: self.client.clone(),
+            api_version: Some(api_version.to_string()),
         }
     }
 
@@ -336,5 +355,12 @@ impl ApiClient {
     /// Get the configured API base URL.
     pub fn api_base_url(&self) -> &str {
         &self.api_base_url
+    }
+
+    /// Get the CDF API version this client will use.
+    /// Any requests made with the request builder will append a header
+    /// cdf-version with this value, if it is set.
+    pub fn api_version(&self) -> Option<&str> {
+        self.api_version.as_deref()
     }
 }

--- a/cognite/src/api/data_modeling.rs
+++ b/cognite/src/api/data_modeling.rs
@@ -3,9 +3,12 @@ pub(crate) mod data_models;
 pub(crate) mod instances;
 // pub(crate) mod resource;
 pub(crate) mod spaces;
+pub(crate) mod streams;
 pub(crate) mod views;
 
 use std::sync::Arc;
+
+use streams::StreamsResource;
 
 use crate::api::data_modeling::{instances::Instances, views::ViewsResource};
 use crate::ApiClient;
@@ -26,6 +29,8 @@ pub struct Models {
     pub data_models: DataModelsResource,
     /// Data modeling containers.
     pub containers: ContainersResource,
+    /// Data modeling streams.
+    pub streams: StreamsResource,
 }
 
 impl Models {
@@ -36,6 +41,7 @@ impl Models {
             spaces: SpacesResource::new(api_client.clone()),
             data_models: DataModelsResource::new(api_client.clone()),
             containers: ContainersResource::new(api_client.clone()),
+            streams: StreamsResource::new(Arc::new(api_client.clone_with_api_version("beta"))),
         }
     }
 }

--- a/cognite/src/api/data_modeling/streams.rs
+++ b/cognite/src/api/data_modeling/streams.rs
@@ -1,0 +1,38 @@
+use crate::{
+    models::records::{ListStreamParams, Stream, StreamWrite},
+    Create, List, Resource, WithBasePath,
+};
+
+pub type StreamsResource = Resource<Stream>;
+
+impl WithBasePath for StreamsResource {
+    const BASE_PATH: &'static str = "streams";
+}
+
+impl Create<StreamWrite, Stream> for StreamsResource {}
+impl List<ListStreamParams, Stream> for StreamsResource {}
+
+impl StreamsResource {
+    /// Retrieve a stream by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream_id` - ID of the stream to retrieve.
+    pub async fn retrieve(&self, stream_id: &str) -> crate::error::Result<Stream> {
+        self.api_client
+            .get(&format!("{}/{}", Self::BASE_PATH, stream_id))
+            .await
+    }
+
+    /// Delete a stream by its ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream_id` - ID of the stream to delete.
+    pub async fn delete(&self, stream_id: &str) -> crate::error::Result<()> {
+        self.api_client
+            .delete::<serde_json::Value>(&format!("{}/{}", Self::BASE_PATH, stream_id))
+            .await?;
+        Ok(())
+    }
+}

--- a/cognite/src/api/request_builder/builder.rs
+++ b/cognite/src/api/request_builder/builder.rs
@@ -211,6 +211,12 @@ impl<T: ResponseHandler> RequestBuilder<'_, T> {
                 "x-cdp-app",
                 HeaderValue::from_str(self.client.app_name()).expect("Invalid app name"),
             );
+        if let Some(cdf_version) = self.client.api_version() {
+            self.inner = self.inner.header(
+                "cdf-version",
+                HeaderValue::from_str(cdf_version).expect("Invalid CDF version"),
+            );
+        }
 
         match self.inner.send().await {
             Ok(response) => {

--- a/cognite/src/dto/data_modeling.rs
+++ b/cognite/src/dto/data_modeling.rs
@@ -4,4 +4,5 @@ pub(crate) mod data_models;
 pub(crate) mod instances;
 pub(crate) mod query;
 pub(crate) mod spaces;
+pub(crate) mod streams;
 pub(crate) mod views;

--- a/cognite/src/dto/data_modeling/streams.rs
+++ b/cognite/src/dto/data_modeling/streams.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+use crate::IntoParams;
+
+/// A stream to create in CDF.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StreamWrite {
+    /// Stream identifier. The identifier must be unique within the project
+    /// and must be a valid stream identifier. Stream identifiers can
+    /// only consist of alphanumeric characters, hyphens, and underscores.
+    /// It must not start with cdf_ or cognite_, as those are reserved
+    /// for future use. Stream id cannot be logs or records.
+    /// Max length is 100 characters.
+    pub external_id: String,
+}
+
+impl From<Stream> for StreamWrite {
+    fn from(stream: Stream) -> Self {
+        Self {
+            external_id: stream.external_id,
+        }
+    }
+}
+
+/// A stream in CDF.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Stream {
+    /// Stream identifier.
+    pub external_id: String,
+    /// Time the stream was created.
+    pub created_time: i64,
+}
+
+/// Query parameters for listing streams.
+#[derive(Debug, Default)]
+pub struct ListStreamParams {}
+
+impl IntoParams for ListStreamParams {
+    fn into_params(self) -> Vec<(String, String)> {
+        vec![]
+    }
+}

--- a/cognite/src/lib.rs
+++ b/cognite/src/lib.rs
@@ -131,6 +131,11 @@ pub mod models {
         pub use crate::dto::filter::filter_methods::*;
         pub use crate::dto::filter::*;
     }
+
+    /// Records are event-like items contained in a stream, but modelled using data modelling.
+    pub mod records {
+        pub use crate::dto::data_modeling::streams::*;
+    }
 }
 
 /// Groups are used to give principals the capabilities to access CDF resources. One principal

--- a/cognite/tests/records_tests.rs
+++ b/cognite/tests/records_tests.rs
@@ -1,0 +1,142 @@
+#![cfg(feature = "integration_tests")]
+
+mod common;
+use std::sync::LazyLock;
+
+use cognite::models::records::StreamWrite;
+use cognite::{Create, List};
+use common::*;
+
+use serde_json::json;
+use tokio::sync::Mutex;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn create_and_delete_stream_instance() {
+    // It may be possible to make this an integration test in the future.
+    // For now, streams/records team recommends not creating streams automatically in tests.
+
+    let mock_server = MockServer::start().await;
+    let project = "test";
+    let external_id = "test-stream";
+
+    // Register mock for creating a stream
+    Mock::given(method("POST"))
+        .and(path(get_path("", project, "streams")))
+        .and(body_json(json!({
+            "items": [
+                {
+                    "externalId": external_id,
+                }
+            ]
+        })))
+        .and(header("cdf-version", "beta"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "externalId": external_id,
+                "createdTime": 123456789,
+            }]
+        })))
+        .mount(&mock_server)
+        .await;
+    // Register mock for retrieving a stream
+    Mock::given(method("GET"))
+        .and(path(get_path(
+            "",
+            project,
+            &format!("streams/{}", external_id),
+        )))
+        .and(header("cdf-version", "beta"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "externalId": external_id,
+            "createdTime": 123456789,
+        })))
+        .mount(&mock_server)
+        .await;
+    // Register mock for listing streams
+    Mock::given(method("GET"))
+        .and(path(get_path("", project, "streams")))
+        .and(header("cdf-version", "beta"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "externalId": external_id,
+                "createdTime": 123456789,
+            }]
+        })))
+        .mount(&mock_server)
+        .await;
+    // Register mock for deleting a stream
+    Mock::given(method("DELETE"))
+        .and(path(get_path(
+            "",
+            project,
+            &format!("streams/{}", external_id),
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock_server)
+        .await;
+
+    let client = get_client_for_mocking(&mock_server.uri(), project);
+
+    let stream = client
+        .models
+        .streams
+        .create(&[StreamWrite {
+            external_id: external_id.to_owned(),
+        }])
+        .await
+        .unwrap();
+
+    assert_eq!(stream.len(), 1);
+    let stream = &stream[0];
+    assert_eq!(stream.external_id, external_id);
+
+    let stream_retrieve = client.models.streams.retrieve(&external_id).await.unwrap();
+    assert_eq!(stream_retrieve.external_id, external_id);
+
+    let stream_list = client.models.streams.list(None).await.unwrap();
+    assert_eq!(stream_list.items.len(), 1);
+    assert_eq!(stream_list.items[0].external_id, external_id);
+
+    client.models.streams.delete(&external_id).await.unwrap();
+}
+
+static STREAM_ENSURE_LOCK: LazyLock<Mutex<bool>> = LazyLock::new(|| tokio::sync::Mutex::new(false));
+
+async fn ensure_stream(client: &cognite::CogniteClient, external_id: &str) -> cognite::Result<()> {
+    let ensured = STREAM_ENSURE_LOCK.lock().await;
+    if *ensured {
+        return Ok(());
+    }
+    match client.models.streams.retrieve(external_id).await {
+        Ok(_) => return Ok(()),
+        Err(cognite::Error::NotFound(_)) => {
+            client
+                .models
+                .streams
+                .create(&[StreamWrite {
+                    external_id: external_id.to_owned(),
+                }])
+                .await?;
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_retrieve_stream() {
+    let client = get_client();
+    let stream_external_id = "rust-sdk-test-stream";
+    ensure_stream(&client, stream_external_id).await.unwrap();
+    let stream = client
+        .models
+        .streams
+        .retrieve(stream_external_id)
+        .await
+        .unwrap();
+    assert_eq!(stream.external_id, stream_external_id);
+}


### PR DESCRIPTION
We were asked not to integration test create/delete for the time being, as there are limits on the number of soft-deleted streams, which we would run into.

This required some very minor changes to core functionality, since we didn't actually have a way to set the cdf-version header. I think the solution is pretty neat.