### PR TITLE
Disable large_enum_variant lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
-members = [
-    "cognite",
-    "cognite-codegen"
-]
+members = ["cognite", "cognite-codegen"]
 resolver = "2"
+
+[workspace.lints.rust]
+
+[workspace.lints.clippy]
+large_enum_variant = "allow"

--- a/cognite-codegen/Cargo.toml
+++ b/cognite-codegen/Cargo.toml
@@ -3,5 +3,8 @@ name = "cognite-codegen"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 prost-build = "^0.13"

--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -9,6 +9,9 @@ name = "cognite"
 publish = false
 version = "0.4.2"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 integration_tests = []


### PR DESCRIPTION
As of Rust 1.87, CI fails because of the `large_enum_variant` lint.

<details><summary>Expand to see warnings</summary>

```
warning: large size difference between variants
   --> cognite/src/dto/data_modeling/query.rs:170:1
    |
170 | / pub enum QueryTableExpression {
171 | |     /// Query nodes.
172 | |     Node(QueryNodeTableExpression),
    | |     ------------------------------ the second-largest variant contains at least 336 bytes
173 | |     /// Query edges.
174 | |     Edge(QueryEdgeTableExpression),
    | |     ------------------------------ the largest variant contains at least 632 bytes
175 | |     /// Perform complex operations on other query results.
176 | |     SetOperation(QuerySetOperationTableExpression),
177 | | }
    | |_^ the entire enum is at least 632 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
    |
174 -     Edge(QueryEdgeTableExpression),
174 +     Edge(Box<QueryEdgeTableExpression>),
    |
```
```
warning: large size difference between variants
  --> cognite/src/dto/data_modeling/views.rs:75:1
   |
75 | / pub enum ViewCreateOrReference {
76 | |     /// Create a new view.
77 | |     Create(ViewCreateDefinition),
   | |     ---------------------------- the largest variant contains at least 376 bytes
78 | |     /// Reference an existing view.
79 | |     Reference(ViewReference),
   | |     ------------------------ the second-largest variant contains at least 72 bytes
80 | | }
   | |_^ the entire enum is at least 376 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
77 -     Create(ViewCreateDefinition),
77 +     Create(Box<ViewCreateDefinition>),
   |
```
```
warning: large size difference between variants
  --> cognite/src/dto/data_modeling/views.rs:94:1
   |
94 | / pub enum ViewDefinitionOrReference {
95 | |     /// Definition for a newly created view.
96 | |     Definition(ViewDefinition),
   | |     -------------------------- the largest variant contains at least 392 bytes
97 | |     /// Refernece to an existing view.
98 | |     Reference(ViewReference),
   | |     ------------------------ the second-largest variant contains at least 72 bytes
99 | | }
   | |_^ the entire enum is at least 392 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
96 -     Definition(ViewDefinition),
96 +     Definition(Box<ViewDefinition>),
   |
```
</details>

In typical usage of the Rust SDK, a size difference of <1kB should be relatively insignificant, and boxing the fields has other downsides including being breaking changes and getting in the way of pattern destructuring.

As such, I propose that the `large_enum_variants` is instead simply disabled for the repository.