### PR TITLE
Allow retriving files by IdentityOrInstance

### DIFF
--- a/cognite/src/api/core/files.rs
+++ b/cognite/src/api/core/files.rs
@@ -19,6 +19,7 @@ impl WithBasePath for Files {
 impl FilterWithRequest<PartitionedFilter<FileFilter>, FileMetadata> for Files {}
 impl SearchItems<'_, FileFilter, FileSearch, FileMetadata> for Files {}
 impl RetrieveWithIgnoreUnknownIds<Identity, FileMetadata> for Files {}
+impl RetrieveWithIgnoreUnknownIds<IdentityOrInstance, FileMetadata> for Files {}
 impl Delete<Identity> for Files {}
 impl Update<Patch<PatchFile>, FileMetadata> for Files {}
 


### PR DESCRIPTION
The [retrieve files endpoint][1] allows `id`, `externalId` and `instanceId`, but the SDK only allows for `id` and `externalId` (with the `Identity` type). This PR also allows for `instanceId` to be used with the `IdentityOrInstance` type when retrieving files.

[1]: https://api-docs.cognite.com/20230101/tag/Files/operation/byIdsFiles