### PR TITLE
Make CogniteClient cloneable

### DIFF
--- a/cognite/src/api/data_modeling.rs
+++ b/cognite/src/api/data_modeling.rs
@@ -19,6 +19,7 @@ use self::containers::ContainersResource;
 use self::data_models::DataModelsResource;
 use self::spaces::SpacesResource;
 
+#[derive(Clone)]
 /// API resource for data modeling.
 pub struct Models {
     /// Data model instances (nodes and edges)

--- a/cognite/src/api/resource.rs
+++ b/cognite/src/api/resource.rs
@@ -37,6 +37,15 @@ impl<T> Resource<T> {
     }
 }
 
+impl<T> Clone for Resource<T> {
+    fn clone(&self) -> Self {
+        Self {
+            api_client: self.api_client.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
 impl<T> WithApiClient for Resource<T> {
     fn get_client(&self) -> &ApiClient {
         &self.api_client

--- a/cognite/src/cognite_client.rs
+++ b/cognite/src/cognite_client.rs
@@ -65,6 +65,7 @@ pub struct ClientConfig {
     pub initial_delay_ms: Option<u64>,
 }
 
+#[derive(Clone)]
 /// Client object for the CDF API.
 pub struct CogniteClient {
     /// Reference to an API client, which can let you make


### PR DESCRIPTION
Because `CogniteClient` is in practice cheaply cloneable, it should implement `Clone`. This PR adds a `Clone` derive for `CogniteClient` and types it contains.