### PR TITLE
Remove Sync constraints from methods accepting streams

### DIFF
--- a/cognite/src/api/api_client.rs
+++ b/cognite/src/api/api_client.rs
@@ -252,7 +252,7 @@ impl ApiClient {
         known_size: Option<u64>,
     ) -> Result<()>
     where
-        S: futures::TryStream + Send + Sync + 'static,
+        S: futures::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
         bytes::Bytes: From<S::Ok>,
     {

--- a/cognite/src/api/core/files.rs
+++ b/cognite/src/api/core/files.rs
@@ -52,7 +52,7 @@ impl<'a> MultipartUploader<'a> {
     /// * `size` - Size of stream to upload.
     pub async fn upload_part_stream<S>(&self, part_no: usize, stream: S, size: u64) -> Result<()>
     where
-        S: futures::TryStream + Send + Sync + 'static,
+        S: futures::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         bytes::Bytes: From<S::Ok>,
     {
@@ -135,7 +135,7 @@ impl Files {
         stream_chunked: bool,
     ) -> Result<()>
     where
-        S: futures::TryStream + Send + Sync + 'static,
+        S: futures::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         bytes::Bytes: From<S::Ok>,
     {
@@ -178,7 +178,7 @@ impl Files {
         size: u64,
     ) -> Result<()>
     where
-        S: futures::TryStream + Send + Sync + 'static,
+        S: futures::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         bytes::Bytes: From<S::Ok>,
     {


### PR DESCRIPTION
A `Stream` parameter can only be used through a `&mut _` or `Pin<&mut _>`, so it typically doesn't matter if it's `Sync` (meaning shared references `&_` are thread-safe). In particular, the methods of the HTTP library where these stream objects end up do not require them to be `Sync`.

As having stream types that are `Send` but not (proven to be) `Sync` is common, relaxing the constriant seems reasonable.