### PR TITLE
Fill out some missing fields in DM DTOs

### DIFF
--- a/cognite/src/dto/data_modeling/common.rs
+++ b/cognite/src/dto/data_modeling/common.rs
@@ -109,7 +109,7 @@ pub enum UsedFor {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
+#[derive(Default, Serialize, Deserialize, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 /// Description of a text property.
 pub struct TextProperty {
@@ -118,16 +118,37 @@ pub struct TextProperty {
     pub list: Option<bool>,
     /// Optional text collation.
     pub collation: Option<String>,
+    /// Maximum allowed length of the list.
+    pub max_list_size: Option<i32>,
+    /// Maximum allowed size of each text entry, as utf-8 bytes.
+    pub max_text_size: Option<i32>,
 }
 
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+/// Reference to a unit in the Cognite unit catalog.
+pub struct UnitReference {
+    /// The external ID of the unit in the Cognite unit catalog.
+    pub external_id: String,
+    /// The value of the unit in the source.
+    pub source_unit: Option<String>,
+}
+
+#[skip_serializing_none]
+#[derive(Default, Serialize, Deserialize, Derivative, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 /// Description of a primitive property
 pub struct PrimitiveProperty {
     #[derivative(Default(value = "false"))]
     /// Whether this is a list or not.
     pub list: Option<bool>,
+    /// The unit of the data stored in this property.
+    /// Can only be assigned to types float32 or float64,
+    /// external ID needs to match with a unit in the Cognite unit catalog.
+    pub unit: Option<UnitReference>,
+    /// Maximum allowed length of the list.
+    pub max_list_size: Option<i32>,
 }
 
 #[skip_serializing_none]
@@ -160,6 +181,8 @@ pub struct CDFExternalIdReference {
     #[derivative(Default(value = "false"))]
     /// Whether this is a list or not.
     pub list: Option<bool>,
+    /// Maximum allowed length of the list.
+    pub max_list_size: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -6,8 +6,8 @@ use serde_with::skip_serializing_none;
 
 use crate::{
     models::{
-        CDFExternalIdReference, PrimitiveProperty, SourceReference, TaggedContainerReference,
-        TaggedViewReference, TextProperty, UsedFor,
+        CDFExternalIdReference, PrimitiveProperty, TaggedContainerReference, TaggedViewReference,
+        TextProperty, UsedFor,
     },
     to_query, AdvancedFilter, IntoParams, RawValue, SetCursor,
 };
@@ -118,7 +118,7 @@ pub struct ViewCreateDefinition {
     /// Filter for instances included in this view.
     pub filter: Option<AdvancedFilter>,
     /// List of views this view implements.
-    pub implements: Option<Vec<ViewReference>>,
+    pub implements: Option<Vec<TaggedViewReference>>,
     /// Whether this view should be used for nodes, edges, or both.
     pub used_for: Option<UsedFor>,
     /// View version.
@@ -183,7 +183,7 @@ pub struct CreateViewProperty {
     /// The unique identifier for the property (Unique within the referenced container).
     pub container_property_identifier: String,
     /// Indicates what type a referenced direct relation is expected to be.
-    pub source: Option<SourceReference>,
+    pub source: Option<TaggedViewReference>,
 }
 
 impl From<ViewCorePropertyDefinition> for CreateViewProperty {
@@ -232,7 +232,7 @@ pub struct ReverseDirectRelationConnection {
     /// Which property this connection uses.
     pub through: SourcePropertyReference,
     /// Whether this relation targets a list of direct relations.
-    pub targets_list: bool,
+    pub targets_list: Option<bool>,
 }
 
 #[skip_serializing_none]
@@ -267,7 +267,7 @@ pub struct ViewDefinition {
     /// Filter for instances in view.
     pub filter: Option<AdvancedFilter>,
     /// List of views this view implements.
-    pub implements: Option<Vec<ViewReference>>,
+    pub implements: Option<Vec<TaggedViewReference>>,
     /// Version of view.
     pub version: String,
     /// Time this view was created, in milliseconds since epoch.
@@ -292,6 +292,26 @@ pub enum ViewDefinitionProperties {
     ViewCorePropertyDefinition(ViewCorePropertyDefinition),
     /// A connection to a view.
     ConnectionDefinition(ConnectionDefinition),
+}
+
+#[derive(Serialize, Deserialize, Derivative, Clone, Debug, Copy)]
+#[serde(rename_all = "camelCase")]
+/// Validity state of a constraint or index.
+pub enum ConstraintOrIndexState {
+    /// The constraint is violated.
+    Failed,
+    /// The constraint is currently satisfied.
+    Current,
+    /// The constraint is pending validation.
+    Pending,
+}
+
+#[derive(Serialize, Deserialize, Derivative, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+/// State of constraints on a property.
+pub struct ViewConstraintState {
+    /// Status of nullability on properties with isNullable set to false.
+    nullability: Option<ConstraintOrIndexState>,
 }
 
 #[skip_serializing_none]
@@ -319,6 +339,9 @@ pub struct ViewCorePropertyDefinition {
     #[serde(default)]
     /// Whether this property is immutable.
     pub immutable: bool,
+    #[serde(default)]
+    /// State of constraints on this property.
+    pub constraint_state: ViewConstraintState,
 }
 
 #[derive(Serialize, Deserialize, Derivative, Clone, Debug)]
@@ -365,4 +388,9 @@ pub struct ViewDirectNodeRelation {
     pub container: Option<TaggedContainerReference>,
     /// Hint showing the view that the direct relation points to.
     pub source: Option<TaggedViewReference>,
+    #[serde(default)]
+    /// Whether this property is a list.
+    pub list: bool,
+    /// Maximum number of items in the list, if this is a list property.
+    pub max_list_size: Option<i32>,
 }

--- a/cognite/tests/containers_tests.rs
+++ b/cognite/tests/containers_tests.rs
@@ -41,10 +41,7 @@ async fn create_retrieve_delete_container() {
                 default_value: None,
                 description: None,
                 auto_increment: None,
-                r#type: ContainerPropertyType::Text(TextProperty {
-                    list: None,
-                    collation: None,
-                }),
+                r#type: ContainerPropertyType::Text(TextProperty::default()),
             },
         )]),
     };

--- a/cognite/tests/views_tests.rs
+++ b/cognite/tests/views_tests.rs
@@ -166,5 +166,15 @@ async fn test_retrieve_complex_view() {
         c
     );
     assert_eq!(prop.name, Some("Activities".to_string()));
-    assert!(prop.targets_list);
+    assert!(prop.targets_list.unwrap_or_default());
+
+    // Check that a list direct relation looks good.
+    let prop = assert_is!(
+        view.properties.get("assets"),
+        Some(ViewDefinitionProperties::ViewCorePropertyDefinition(v)),
+        v
+    );
+    assert_eq!(prop.name, Some("Assets".to_string()));
+    let ty = assert_is!(&prop.r#type, ViewCorePropertyType::Direct(v), v);
+    assert!(ty.list);
 }


### PR DESCRIPTION
Specifically I need `list` on direct relation types, but the others are nice to have.