### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+profile = "default"
+components = [ "clippy", "rustfmt", "rust-src" ]


### PR DESCRIPTION
This change adds the missing `rust-toolchain.toml` which specifies the channel and additional components for rustup.