### PR TITLE
Fix clippy::useless_conversion warning in time_series

### DIFF
--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -198,7 +198,7 @@ impl TimeSeriesResource {
             Some(m) => m,
             None => return result,
         };
-        let idt_set = HashSet::<IdentityOrInstance>::from_iter(missing_idts.into_iter());
+        let idt_set = HashSet::<IdentityOrInstance>::from_iter(missing_idts);
 
         let mut items = vec![];
         for elem in add_datapoints.items.iter() {


### PR DESCRIPTION
[Github Actions](https://github.com/cognitedata/cognite-sdk-rust/actions/workflows/build-and-test.yml) were failing due to a clippy warning.

Remove redundant `into_iter()` call in time_series.

`HashSet::from_iter()` already accepts IntoIterator, so the explicit `.into_iter()` call is unnecessary and triggers a clippy warning.