### PR TITLE
Adding SpaceQuery to allow listing global spaces

### DIFF
--- a/cognite/src/api/data_modeling/spaces.rs
+++ b/cognite/src/api/data_modeling/spaces.rs
@@ -1,9 +1,9 @@
 use crate::{
     models::{
-        spaces::{Space, SpaceCreate},
+        spaces::{Space, SpaceCreate, SpaceQuery},
         SpaceId,
     },
-    Create, DeleteWithResponse, LimitCursorQuery, List, Resource, Retrieve, WithBasePath,
+    Create, DeleteWithResponse, List, Resource, Retrieve, WithBasePath,
 };
 
 /// Spaces contain and namespace instances, views, and containers.
@@ -15,6 +15,6 @@ impl WithBasePath for SpacesResource {
 }
 
 impl Create<SpaceCreate, Space> for SpacesResource {}
-impl List<LimitCursorQuery, Space> for SpacesResource {}
 impl Retrieve<SpaceId, Space> for SpacesResource {}
 impl DeleteWithResponse<SpaceId, SpaceId> for SpacesResource {}
+impl List<SpaceQuery, Space> for SpacesResource {}

--- a/cognite/src/dto/data_modeling/spaces.rs
+++ b/cognite/src/dto/data_modeling/spaces.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+use crate::{to_query, IntoParams, SetCursor};
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
@@ -33,4 +34,31 @@ pub struct Space {
     pub last_updated_time: i64,
     /// Whether this space is a global space.
     pub is_global: bool,
+}
+
+#[derive(Default, Clone, Debug)]
+/// Query for listing spaces.
+pub struct SpaceQuery {
+    /// Maximum number of spaces in the result.
+    pub limit: Option<i32>,
+    /// Optional cursor for pagination.
+    pub cursor: Option<String>,
+    /// Include global spaces.
+    pub include_global: Option<bool>,
+}
+
+impl IntoParams for SpaceQuery {
+    fn into_params(self) -> Vec<(String, String)> {
+        let mut params = Vec::new();
+        to_query("limit", &self.limit, &mut params);
+        to_query("cursor", &self.cursor, &mut params);
+        to_query("includeGlobal", &self.include_global, &mut params);
+        params
+    }
+}
+
+impl SetCursor for SpaceQuery {
+    fn set_cursor(&mut self, cursor: Option<String>) {
+        self.cursor = cursor;
+    }
 }

--- a/cognite/src/dto/data_modeling/spaces.rs
+++ b/cognite/src/dto/data_modeling/spaces.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{to_query, IntoParams, SetCursor};
+use crate::{to_query, IntoParams, LimitCursorQuery, SetCursor};
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
@@ -60,5 +60,15 @@ impl IntoParams for SpaceQuery {
 impl SetCursor for SpaceQuery {
     fn set_cursor(&mut self, cursor: Option<String>) {
         self.cursor = cursor;
+    }
+}
+
+impl From<LimitCursorQuery> for SpaceQuery {
+    fn from(q: LimitCursorQuery) -> Self {
+        Self {
+            limit: q.limit,
+            cursor: q.cursor,
+            include_global: None,
+        }
     }
 }

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -2,8 +2,6 @@
 
 mod common;
 
-use cognite::models::spaces::SpaceCreate;
-
 use cognite::models::*;
 
 use cognite::*;
@@ -14,46 +12,6 @@ use instances::{
     SlimNodeOrEdge, Timeseries,
 };
 use uuid::Uuid;
-
-#[tokio::test]
-async fn create_retrieve_delete_spaces() {
-    let _permit = CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
-    let space_id = format!("{}-space-1", PREFIX.as_str());
-    let client = get_client();
-    let new_space = SpaceCreate {
-        space: space_id.clone(),
-        description: Some("Some description".to_owned()),
-        name: Some("Test space".to_owned()),
-    };
-    let created = client.models.spaces.create(&[new_space]).await.unwrap();
-    assert_eq!(created.len(), 1);
-    let space = &created[0];
-    assert_eq!(space.name, Some("Test space".to_owned()));
-
-    let retrieved = client
-        .models
-        .spaces
-        .retrieve(&[SpaceId {
-            space: space_id.clone(),
-        }])
-        .await
-        .unwrap();
-    assert_eq!(retrieved.len(), 1);
-    let space = &retrieved[0];
-    assert_eq!(space.name, Some("Test space".to_owned()));
-
-    let deleted = client
-        .models
-        .spaces
-        .delete(&[SpaceId {
-            space: space_id.clone(),
-        }])
-        .await
-        .unwrap();
-    assert_eq!(deleted.items.len(), 1);
-    let space = &deleted.items[0];
-    assert_eq!(space_id, space.space);
-}
 
 #[tokio::test]
 async fn create_and_delete_file_instance() {

--- a/cognite/tests/spaces_test.rs
+++ b/cognite/tests/spaces_test.rs
@@ -1,0 +1,103 @@
+#![cfg(feature = "integration_tests")]
+
+#[cfg(test)]
+use cognite::models::*;
+use cognite::{
+    models::spaces::{SpaceCreate, SpaceQuery},
+    CogniteClient,
+};
+use cognite::{Create, List, Retrieve};
+
+mod common;
+
+use cognite::*;
+mod fixtures;
+pub use fixtures::*;
+
+#[tokio::test]
+async fn create_retrieve_delete_spaces() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let space_id = format!("{}-space-1", common::PREFIX.as_str());
+    let client = common::get_client();
+    let new_space = SpaceCreate {
+        space: space_id.clone(),
+        description: Some("Some description".to_owned()),
+        name: Some("Test space".to_owned()),
+    };
+    let created = client.models.spaces.create(&[new_space]).await.unwrap();
+    assert_eq!(created.len(), 1);
+    let space = &created[0];
+    assert_eq!(space.name, Some("Test space".to_owned()));
+
+    let retrieved = client
+        .models
+        .spaces
+        .retrieve(&[SpaceId {
+            space: space_id.clone(),
+        }])
+        .await
+        .unwrap();
+    assert_eq!(retrieved.len(), 1);
+    let space = &retrieved[0];
+    assert_eq!(space.name, Some("Test space".to_owned()));
+
+    let deleted = client
+        .models
+        .spaces
+        .delete(&[SpaceId {
+            space: space_id.clone(),
+        }])
+        .await
+        .unwrap();
+    assert_eq!(deleted.items.len(), 1);
+    let space = &deleted.items[0];
+    assert_eq!(space_id, space.space);
+}
+
+#[tokio::test]
+async fn list_non_global_spaces() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let client: CogniteClient = common::get_client();
+    let spaces = client
+        .models
+        .spaces
+        .list(Some(SpaceQuery::default()))
+        .await
+        .unwrap();
+    let spaces_list = client.models.spaces.list(None).await.unwrap();
+    assert_eq!(spaces.items.len(), spaces_list.items.len());
+}
+
+#[tokio::test]
+async fn list_global_spaces() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let client: CogniteClient = common::get_client();
+    let spaces = client
+        .models
+        .spaces
+        .list(Some(SpaceQuery {
+            limit: Some(10),
+            include_global: Some(true),
+            cursor: None,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(spaces.items.len(), 10);
+}
+
+#[tokio::test]
+async fn cursoring_global_spaces() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let client: CogniteClient = common::get_client();
+    let spaces = client
+        .models
+        .spaces
+        .list_all(SpaceQuery {
+            limit: Some(10),
+            include_global: Some(true),
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert!(spaces.len() > 11);
+}

--- a/cognite/tests/spaces_test.rs
+++ b/cognite/tests/spaces_test.rs
@@ -86,6 +86,30 @@ async fn list_global_spaces() {
 }
 
 #[tokio::test]
+async fn list_spaces_accepts_limit_cursor_query() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let client: CogniteClient = common::get_client();
+    let query = LimitCursorQuery {
+        limit: Some(5),
+        cursor: None,
+    };
+    let spaces = client.models.spaces.list(Some(query.into())).await.unwrap();
+    assert!(spaces.items.len() <= 5);
+}
+
+#[tokio::test]
+async fn list_all_spaces_accepts_limit_cursor_query() {
+    let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
+    let client: CogniteClient = common::get_client();
+    let query = LimitCursorQuery {
+        limit: Some(5),
+        cursor: None,
+    };
+    let spaces = client.models.spaces.list_all(query.into()).await.unwrap();
+    assert!(!spaces.is_empty());
+}
+
+#[tokio::test]
 async fn cursoring_global_spaces() {
     let _permit = common::CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
     let client: CogniteClient = common::get_client();


### PR DESCRIPTION
Attempting to add SpaceQuery in order to support fetching global spaces from **/models/spaces** as `LimitCursorQuery` does not allow controlling `includeGlobal` so it is currently not supported to fetch global data modeling spaces.

This PR adds `SpaceQuery` that has a property `include_global`.

Added integration test in separate file. These run against the CDF API - is this okay or is mocking preferred?