### PR TITLE
fix: Correcting serialization of DataModelCreate

### DIFF
--- a/cognite/src/dto/data_modeling/views.rs
+++ b/cognite/src/dto/data_modeling/views.rs
@@ -76,14 +76,14 @@ pub enum ViewCreateOrReference {
     /// Create a new view.
     Create(ViewCreateDefinition),
     /// Reference an existing view.
-    Reference(ViewReference),
+    Reference(TaggedViewReference),
 }
 
 impl From<ViewDefinitionOrReference> for ViewCreateOrReference {
     fn from(value: ViewDefinitionOrReference) -> Self {
         match value {
             ViewDefinitionOrReference::Definition(x) => Self::Create(x.into()),
-            ViewDefinitionOrReference::Reference(x) => Self::Reference(x),
+            ViewDefinitionOrReference::Reference(x) => Self::Reference(x.into()),
         }
     }
 }

--- a/cognite/src/error.rs
+++ b/cognite/src/error.rs
@@ -126,8 +126,8 @@ impl fmt::Display for CdfApiError {
         write!(
             f,
             "{}: {}. RequestId: {}",
-            &self.code,
-            &self.message,
+            self.code,
+            self.message,
             self.request_id.as_deref().unwrap_or("")
         )
     }

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -1,4 +1,4 @@
-// #![cfg(feature = "integration_tests")]
+#![cfg(feature = "integration_tests")]
 
 mod common;
 

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -67,7 +67,7 @@ async fn create_retrieve_delete_spaces_and_data_model() {
         .unwrap();
     assert_eq!(data_model_created.len(), 1);
 
-    let data_model_retrieved = client
+    let data_model_deleted = client
         .models
         .data_models
         .delete(&[DataModelId {
@@ -77,7 +77,7 @@ async fn create_retrieve_delete_spaces_and_data_model() {
         }])
         .await
         .unwrap();
-    assert_eq!(data_model_retrieved.items.len(), 1);
+    assert_eq!(data_model_deleted.items.len(), 1);
 
     let deleted = client
         .models

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -2,7 +2,9 @@
 
 mod common;
 
-use cognite::models::spaces::SpaceCreate;
+use cognite::models::data_models::DataModelId;
+use cognite::models::views::{ViewCreateOrReference, ViewReference};
+use cognite::models::{data_models::DataModelCreate, spaces::SpaceCreate};
 
 use cognite::models::*;
 
@@ -16,7 +18,7 @@ use instances::{
 use uuid::Uuid;
 
 #[tokio::test]
-async fn create_retrieve_delete_spaces() {
+async fn create_retrieve_delete_spaces_and_data_model() {
     let _permit = CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
     let space_id = format!("{}-space-1", PREFIX.as_str());
     let client = get_client();
@@ -41,6 +43,41 @@ async fn create_retrieve_delete_spaces() {
     assert_eq!(retrieved.len(), 1);
     let space = &retrieved[0];
     assert_eq!(space.name, Some("Test space".to_owned()));
+
+    let data_model_create = DataModelCreate {
+        space: space_id.clone(),
+        external_id: "DM1".to_string(),
+        version: "1".to_string(),
+        name: None,
+        description: None,
+        views: Some(vec![ViewCreateOrReference::Reference(
+            ViewReference {
+                space: "cdf_cdm".to_string(),
+                external_id: "CogniteAsset".to_string(),
+                version: "v1".to_string(),
+            }
+            .into(),
+        )]),
+    };
+    let data_model_created = client
+        .models
+        .data_models
+        .create(&[data_model_create])
+        .await
+        .unwrap();
+    assert_eq!(data_model_created.len(), 1);
+
+    let data_model_retrieved = client
+        .models
+        .data_models
+        .delete(&[DataModelId {
+            space: space_id.clone(),
+            external_id: "DM1".to_string(),
+            version: Some("1".to_string()),
+        }])
+        .await
+        .unwrap();
+    assert_eq!(data_model_retrieved.items.len(), 1);
 
     let deleted = client
         .models

--- a/cognite/tests/data_models_tests.rs
+++ b/cognite/tests/data_models_tests.rs
@@ -1,10 +1,10 @@
-#![cfg(feature = "integration_tests")]
+// #![cfg(feature = "integration_tests")]
 
 mod common;
 
+use cognite::models::data_models::DataModelCreate;
 use cognite::models::data_models::DataModelId;
 use cognite::models::views::{ViewCreateOrReference, ViewReference};
-use cognite::models::{data_models::DataModelCreate, spaces::SpaceCreate};
 
 use cognite::models::*;
 
@@ -18,34 +18,12 @@ use instances::{
 use uuid::Uuid;
 
 #[tokio::test]
-async fn create_retrieve_delete_spaces_and_data_model() {
+async fn create_delete_data_models() {
     let _permit = CDM_CONCURRENCY_PERMITS.acquire().await.unwrap();
-    let space_id = format!("{}-space-1", PREFIX.as_str());
     let client = get_client();
-    let new_space = SpaceCreate {
-        space: space_id.clone(),
-        description: Some("Some description".to_owned()),
-        name: Some("Test space".to_owned()),
-    };
-    let created = client.models.spaces.create(&[new_space]).await.unwrap();
-    assert_eq!(created.len(), 1);
-    let space = &created[0];
-    assert_eq!(space.name, Some("Test space".to_owned()));
-
-    let retrieved = client
-        .models
-        .spaces
-        .retrieve(&[SpaceId {
-            space: space_id.clone(),
-        }])
-        .await
-        .unwrap();
-    assert_eq!(retrieved.len(), 1);
-    let space = &retrieved[0];
-    assert_eq!(space.name, Some("Test space".to_owned()));
-
-    let data_model_create = DataModelCreate {
-        space: space_id.clone(),
+    let space = std::env::var("CORE_DM_TEST_SPACE").unwrap();
+    let data_model_1 = DataModelCreate {
+        space: space.clone(),
         external_id: "DM1".to_string(),
         version: "1".to_string(),
         name: None,
@@ -59,37 +37,41 @@ async fn create_retrieve_delete_spaces_and_data_model() {
             .into(),
         )]),
     };
+
+    let data_model_2 = DataModelCreate {
+        space: space.clone(),
+        external_id: "DM2".to_string(),
+        version: "1".to_string(),
+        name: None,
+        description: None,
+        views: None,
+    };
     let data_model_created = client
         .models
         .data_models
-        .create(&[data_model_create])
+        .create(&[data_model_1, data_model_2])
         .await
         .unwrap();
-    assert_eq!(data_model_created.len(), 1);
+    assert_eq!(data_model_created.len(), 2);
 
     let data_model_deleted = client
         .models
         .data_models
-        .delete(&[DataModelId {
-            space: space_id.clone(),
-            external_id: "DM1".to_string(),
-            version: Some("1".to_string()),
-        }])
+        .delete(&[
+            DataModelId {
+                space: space.clone(),
+                external_id: "DM1".to_string(),
+                version: Some("1".to_string()),
+            },
+            DataModelId {
+                space: space.clone(),
+                external_id: "DM2".to_string(),
+                version: Some("1".to_string()),
+            },
+        ])
         .await
         .unwrap();
-    assert_eq!(data_model_deleted.items.len(), 1);
-
-    let deleted = client
-        .models
-        .spaces
-        .delete(&[SpaceId {
-            space: space_id.clone(),
-        }])
-        .await
-        .unwrap();
-    assert_eq!(deleted.items.len(), 1);
-    let space = &deleted.items[0];
-    assert_eq!(space_id, space.space);
+    assert_eq!(data_model_deleted.items.len(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Currently, `DataModelCreate` serializes without the required `"type": "view"` in the request to `models/datamodels` when views are referenced. This makes the API return a 400.

This PR attempts to fix this by using the `TaggedViewReference` and adding a conversion for `ViewDefinitionOrReference`.