### PR TITLE
Use Cognite defaults for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "local>cognitedata/renovate-config-public"
   ],
   "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Use Cognite defaults for Renovate. Cognite defaults include better protection for supply chain attacks, including a cooldown/minReleaseAge period for dependencies.