### PR TITLE
Add initial state time series datapoint support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+cognite/src/dto/core/datapoint/generated/*.rs linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/*.rs.bk
 Cargo.lock
 env_variables
+.env

--- a/cognite-codegen/proto/data_point_insertion_request.proto
+++ b/cognite-codegen/proto/data_point_insertion_request.proto
@@ -16,6 +16,7 @@ message DataPointInsertionItem {
     oneof datapointType {
         NumericDatapoints numericDatapoints = 3;
         StringDatapoints stringDatapoints = 4;
+        StateDatapoints stateDatapoints = 6;
     }
 }
 

--- a/cognite-codegen/proto/data_point_list_response.proto
+++ b/cognite-codegen/proto/data_point_list_response.proto
@@ -6,6 +6,13 @@ import "data_points.proto";
 
 option java_multiple_files = true;
 
+enum TimeSeriesType {
+    TIMESERIES_TYPE_UNSPECIFIED = 0;
+    TIMESERIES_TYPE_NUMERIC = 1;
+    TIMESERIES_TYPE_STRING = 2;
+    TIMESERIES_TYPE_STATE = 3;
+}
+
 message DataPointListItem {
     int64 id = 1;
     string externalId = 2;
@@ -15,11 +22,13 @@ message DataPointListItem {
     string unit = 8;
     string nextCursor = 9;
     string unitExternalId = 10;
+    TimeSeriesType type = 12;
 
     oneof datapointType {
         NumericDatapoints numericDatapoints = 3;
         StringDatapoints stringDatapoints = 4;
         AggregateDatapoints aggregateDatapoints = 5;
+        StateDatapoints stateDatapoints = 13;
     }
 }
 

--- a/cognite-codegen/proto/data_points.proto
+++ b/cognite-codegen/proto/data_points.proto
@@ -31,6 +31,17 @@ message StringDatapoints {
     repeated StringDatapoint datapoints = 1;
 }
 
+message StateDatapoint {
+    int64 timestamp = 1;
+    optional int64 numericValue = 2;
+    optional string stringValue = 3;
+    Status status = 4;
+}
+
+message StateDatapoints {
+    repeated StateDatapoint datapoints = 1;
+}
+
 message AggregateDatapoint {
     int64 timestamp = 1;
     double average = 2;
@@ -49,10 +60,21 @@ message AggregateDatapoint {
     double durationGood = 15;
     double durationUncertain = 16;
     double durationBad = 17;
+    NumericDatapoint maxDatapoint = 18;
+    NumericDatapoint minDatapoint = 19;
+    repeated StateAggregate stateAggregates = 20;
 }
 
 message AggregateDatapoints {
     repeated AggregateDatapoint datapoints = 1;
+}
+
+message StateAggregate {
+    int64 numericValue = 1;
+    optional string stringValue = 2;
+    optional int64 stateCount = 3;
+    optional int64 stateTransitions = 4;
+    optional int64 stateDuration = 5;
 }
 
 message InstanceId {

--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -82,6 +82,8 @@ impl TimeSeriesResource {
         add_datapoints: &DataPointInsertionRequest,
     ) -> Result<()> {
         self.api_client
+            // TODO: remove when state time series is no longer in beta
+            .clone_with_api_version("beta")
             .post_protobuf::<::serde_json::Value, DataPointInsertionRequest>(
                 "timeseries/data",
                 add_datapoints,
@@ -265,6 +267,8 @@ impl TimeSeriesResource {
     ) -> Result<DataPointListResponse> {
         let datapoints_response: DataPointListResponse = self
             .api_client
+            // TODO: remove when state time series is no longer in beta
+            .clone_with_api_version("beta")
             .post_expect_protobuf("timeseries/data/list", &datapoints_filter)
             .await?;
         Ok(datapoints_response)
@@ -284,6 +288,8 @@ impl TimeSeriesResource {
         let query = Items::new_with_extra_fields(items, IgnoreUnknownIds { ignore_unknown_ids });
         let datapoints_response: Items<Vec<LatestDatapointsResponse>> = self
             .api_client
+            // TODO: remove when state time series is no longer in beta
+            .clone_with_api_version("beta")
             .post("timeseries/data/latest", &query)
             .await?;
         Ok(datapoints_response.items)
@@ -297,6 +303,8 @@ impl TimeSeriesResource {
     pub async fn delete_datapoints(&self, query: &[DeleteDatapointsQuery]) -> Result<()> {
         let items = Items::new(query);
         self.api_client
+            // TODO: remove when state time series is no longer in beta
+            .clone_with_api_version("beta")
             .post::<::serde_json::Value, _>("timeseries/data/delete", &items)
             .await?;
         Ok(())

--- a/cognite/src/api/core/time_series.rs
+++ b/cognite/src/api/core/time_series.rs
@@ -74,6 +74,9 @@ impl TimeSeriesResource {
     /// Insert datapoints for a set of timeseries. Any existing datapoints with the
     /// same timestamp will be overwritten.
     ///
+    /// For state time series (currently in beta), use
+    /// [insert_datapoints_proto_beta](Self::insert_datapoints_proto_beta) instead.
+    ///
     /// # Arguments
     ///
     /// * `add_datapoints` - Datapoint batches to insert.
@@ -82,8 +85,6 @@ impl TimeSeriesResource {
         add_datapoints: &DataPointInsertionRequest,
     ) -> Result<()> {
         self.api_client
-            // TODO: remove when state time series is no longer in beta
-            .clone_with_api_version("beta")
             .post_protobuf::<::serde_json::Value, DataPointInsertionRequest>(
                 "timeseries/data",
                 add_datapoints,
@@ -258,10 +259,151 @@ impl TimeSeriesResource {
 
     /// Retrieve datapoints for a collection of time series.
     ///
+    /// For state time series (currently in beta), use
+    /// [retrieve_datapoints_proto_beta](Self::retrieve_datapoints_proto_beta) instead.
+    ///
     /// # Arguments
     ///
     /// * `datapoints_filter` - Filter describing which datapoints to retrieve.
     pub async fn retrieve_datapoints_proto(
+        &self,
+        datapoints_filter: &DatapointsFilter,
+    ) -> Result<DataPointListResponse> {
+        let datapoints_response: DataPointListResponse = self
+            .api_client
+            .post_expect_protobuf("timeseries/data/list", &datapoints_filter)
+            .await?;
+        Ok(datapoints_response)
+    }
+
+    /// Retrieve the latest datapoint before a given time for a list of time series.
+    ///
+    /// For state time series (currently in beta), use
+    /// [retrieve_latest_datapoints_beta](Self::retrieve_latest_datapoints_beta) instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `items` - Queries for latest datapoint.
+    /// * `ignore_unknown_ids` - Set this to `true` to ignore timeseries that do not exist.
+    pub async fn retrieve_latest_datapoints(
+        &self,
+        items: &[LatestDatapointsQuery],
+        ignore_unknown_ids: bool,
+    ) -> Result<Vec<LatestDatapointsResponse>> {
+        let query = Items::new_with_extra_fields(items, IgnoreUnknownIds { ignore_unknown_ids });
+        let datapoints_response: Items<Vec<LatestDatapointsResponse>> = self
+            .api_client
+            .post("timeseries/data/latest", &query)
+            .await?;
+        Ok(datapoints_response.items)
+    }
+
+    /// Delete ranges of datapoints for a list of time series.
+    ///
+    /// For state time series (currently in beta), use
+    /// [delete_datapoints_beta](Self::delete_datapoints_beta) instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - Ranges of datapoints to delete.
+    pub async fn delete_datapoints(&self, query: &[DeleteDatapointsQuery]) -> Result<()> {
+        let items = Items::new(query);
+        self.api_client
+            .post::<::serde_json::Value, _>("timeseries/data/delete", &items)
+            .await?;
+        Ok(())
+    }
+
+    // The methods below are beta-only variants of the datapoints methods above, required for
+    // interacting with datapoints on _state time series_, which is currently a beta CDF feature.
+    // They exist so the stable methods above do not send the `cdf-version: beta` header to
+    // callers who have nothing to do with state time series.
+    //
+    // TODO: once state time series is generally available, delete this block and fold the
+    // relevant functionality back into the corresponding methods above.
+
+    /// Insert datapoints for a set of timeseries. Any existing datapoints with the
+    /// same timestamp will be overwritten.
+    ///
+    /// This is a beta variant of `insert_datapoints`, needed only to insert datapoints into
+    /// _state time series_, which is currently a beta CDF feature. Non-state time series
+    /// should use `insert_datapoints` instead.
+    ///
+    /// Note: datapoints are inserted using protobuf, this converts from a slightly more ergonomic type
+    /// to the protobuf types used directly in `insert_datapoints_proto_beta`.
+    ///
+    /// For very performance intensive workloads, consider using `insert_datapoints_proto_beta`
+    /// directly.
+    ///
+    /// # Arguments
+    ///
+    /// * `add_datapoints` - List of datapoint batches to insert.
+    pub async fn insert_datapoints_beta(&self, add_datapoints: Vec<AddDatapoints>) -> Result<()> {
+        let request = DataPointInsertionRequest::from(add_datapoints);
+        self.insert_datapoints_proto_beta(&request).await?;
+        Ok(())
+    }
+
+    /// Insert datapoints for a set of timeseries. Any existing datapoints with the
+    /// same timestamp will be overwritten.
+    ///
+    /// This is a beta variant of `insert_datapoints_proto`, needed only to insert datapoints
+    /// into _state time series_, which is currently a beta CDF feature. Non-state time series
+    /// should use `insert_datapoints_proto` instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `add_datapoints` - Datapoint batches to insert.
+    pub async fn insert_datapoints_proto_beta(
+        &self,
+        add_datapoints: &DataPointInsertionRequest,
+    ) -> Result<()> {
+        self.api_client
+            // TODO: remove when state time series is no longer in beta
+            .clone_with_api_version("beta")
+            .post_protobuf::<::serde_json::Value, DataPointInsertionRequest>(
+                "timeseries/data",
+                add_datapoints,
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Retrieve datapoints for a collection of time series.
+    ///
+    /// This is a beta variant of `retrieve_datapoints`, needed only to retrieve datapoints from
+    /// _state time series_, which is currently a beta CDF feature. Non-state time series should
+    /// use `retrieve_datapoints` instead.
+    ///
+    /// Note: datapoints are inserted using protobuf, this converts to a slightly more ergonomic type
+    /// from the type returned by `retrieve_datapoints_proto_beta`.
+    ///
+    /// For very performance intensive workloads, consider using `retrieve_datapoints_proto_beta`
+    /// directly.
+    ///
+    /// # Arguments
+    ///
+    /// * `datapoints_filter` - Filter describing which datapoints to retrieve.
+    pub async fn retrieve_datapoints_beta(
+        &self,
+        datapoints_filter: &DatapointsFilter,
+    ) -> Result<Vec<DatapointsResponse>> {
+        let datapoints_response = self
+            .retrieve_datapoints_proto_beta(datapoints_filter)
+            .await?;
+        Ok(DatapointsListResponse::from(datapoints_response).items)
+    }
+
+    /// Retrieve datapoints for a collection of time series.
+    ///
+    /// This is a beta variant of `retrieve_datapoints_proto`, needed only to retrieve datapoints
+    /// from _state time series_, which is currently a beta CDF feature. Non-state time series
+    /// should use `retrieve_datapoints_proto` instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `datapoints_filter` - Filter describing which datapoints to retrieve.
+    pub async fn retrieve_datapoints_proto_beta(
         &self,
         datapoints_filter: &DatapointsFilter,
     ) -> Result<DataPointListResponse> {
@@ -276,11 +418,15 @@ impl TimeSeriesResource {
 
     /// Retrieve the latest datapoint before a given time for a list of time series.
     ///
+    /// This is a beta variant of `retrieve_latest_datapoints`, needed only to retrieve the
+    /// latest datapoint from _state time series_, which is currently a beta CDF feature.
+    /// Non-state time series should use `retrieve_latest_datapoints` instead.
+    ///
     /// # Arguments
     ///
     /// * `items` - Queries for latest datapoint.
     /// * `ignore_unknown_ids` - Set this to `true` to ignore timeseries that do not exist.
-    pub async fn retrieve_latest_datapoints(
+    pub async fn retrieve_latest_datapoints_beta(
         &self,
         items: &[LatestDatapointsQuery],
         ignore_unknown_ids: bool,
@@ -297,10 +443,14 @@ impl TimeSeriesResource {
 
     /// Delete ranges of datapoints for a list of time series.
     ///
+    /// This is a beta variant of `delete_datapoints`, needed only to delete datapoints from
+    /// _state time series_, which is currently a beta CDF feature. Non-state time series
+    /// should use `delete_datapoints` instead.
+    ///
     /// # Arguments
     ///
     /// * `query` - Ranges of datapoints to delete.
-    pub async fn delete_datapoints(&self, query: &[DeleteDatapointsQuery]) -> Result<()> {
+    pub async fn delete_datapoints_beta(&self, query: &[DeleteDatapointsQuery]) -> Result<()> {
         let items = Items::new(query);
         self.api_client
             // TODO: remove when state time series is no longer in beta

--- a/cognite/src/api/core/time_series/datapoints_stream.rs
+++ b/cognite/src/api/core/time_series/datapoints_stream.rs
@@ -353,6 +353,8 @@ impl<'a> DatapointsStream<'a> {
                                 datapoint: EitherDataPoint::Numeric(dp.into()),
                             }));
                         }
+                        // support coming in future PR
+                        Some(ListDatapointType::StateDatapoints(_)) => continue,
                     }
                 }
 

--- a/cognite/src/dto/core/datapoint.rs
+++ b/cognite/src/dto/core/datapoint.rs
@@ -511,7 +511,8 @@ impl<'de> Deserialize<'de> for LatestDatapointsResponse {
                             },
                         )?))
                     // Fall back to `is_string` when `type` is absent or unrecognized.
-                    } else if r.time_series_type == Some(CoreTimeSeriesType::String) || r.is_string {
+                    } else if r.time_series_type == Some(CoreTimeSeriesType::String) || r.is_string
+                    {
                         Some(LatestDatapoint::String(serde_json::from_value(v).map_err(
                             |e| {
                                 D::Error::custom(format!(

--- a/cognite/src/dto/core/datapoint.rs
+++ b/cognite/src/dto/core/datapoint.rs
@@ -17,6 +17,8 @@ pub use self::status_code::*;
 use serde::{de::Error, Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::dto::core::time_series::CoreTimeSeriesType;
+use crate::dto::data_modeling::instances::InstanceId as DmInstanceId;
 use crate::Identity;
 use crate::IdentityOrInstance;
 
@@ -28,6 +30,8 @@ pub enum DatapointsEnumType {
     NumericDatapoints(Vec<DatapointDouble>),
     /// Datapoints with string values.
     StringDatapoints(Vec<DatapointString>),
+    /// Datapoints with state values.
+    StateDatapoints(Vec<DatapointState>),
     /// Aggregate data points.
     AggregateDatapoints(Vec<DatapointAggregate>),
 }
@@ -41,6 +45,12 @@ impl From<Vec<DatapointDouble>> for DatapointsEnumType {
 impl From<Vec<DatapointString>> for DatapointsEnumType {
     fn from(value: Vec<DatapointString>) -> Self {
         Self::StringDatapoints(value)
+    }
+}
+
+impl From<Vec<DatapointState>> for DatapointsEnumType {
+    fn from(value: Vec<DatapointState>) -> Self {
+        Self::StateDatapoints(value)
     }
 }
 
@@ -62,6 +72,13 @@ impl DatapointsEnumType {
     pub fn string(self) -> Option<Vec<DatapointString>> {
         match self {
             Self::StringDatapoints(x) => Some(x),
+            _ => None,
+        }
+    }
+    /// Get self as state datapoints, or none if a different type.
+    pub fn state(self) -> Option<Vec<DatapointState>> {
+        match self {
+            Self::StateDatapoints(x) => Some(x),
             _ => None,
         }
     }
@@ -208,6 +225,20 @@ pub struct DatapointString {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+/// A datapoint with a state value.
+pub struct DatapointState {
+    /// Timestamp in milliseconds since epoch.
+    pub timestamp: i64,
+    /// Numeric representation of the state value.
+    pub numeric_value: Option<i64>,
+    /// String representation of the state value.
+    pub string_value: Option<String>,
+    /// Datapoint status code.
+    pub status: Option<StatusCode>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 /// An aggregate data point.
 pub struct DatapointAggregate {
     /// Timestamp in milliseconds since epoch.
@@ -293,6 +324,28 @@ impl From<DatapointString> for StringDatapoint {
     }
 }
 
+impl From<StateDatapoint> for DatapointState {
+    fn from(dp: StateDatapoint) -> DatapointState {
+        DatapointState {
+            timestamp: dp.timestamp,
+            numeric_value: dp.numeric_value,
+            string_value: dp.string_value,
+            status: dp.status.map(|s| s.into()),
+        }
+    }
+}
+
+impl From<DatapointState> for StateDatapoint {
+    fn from(dp: DatapointState) -> StateDatapoint {
+        StateDatapoint {
+            timestamp: dp.timestamp,
+            numeric_value: dp.numeric_value,
+            string_value: dp.string_value,
+            status: dp.status.map(|s| s.into()),
+        }
+    }
+}
+
 impl From<AggregateDatapoint> for DatapointAggregate {
     fn from(dp: AggregateDatapoint) -> DatapointAggregate {
         DatapointAggregate {
@@ -331,6 +384,10 @@ pub struct DatapointsResponse {
     pub id: i64,
     /// Time series external ID.
     pub external_id: Option<String>,
+    /// Data modeling instance ID of the time series.
+    pub instance_id: Option<DmInstanceId>,
+    /// Time series value type.
+    pub r#type: Option<CoreTimeSeriesType>,
     /// Retrieved datapoints.
     pub datapoints: DatapointsEnumType,
     /// The physical unit of the time series (free-text field).
@@ -356,6 +413,8 @@ pub enum LatestDatapoint {
     Numeric(DatapointDouble),
     /// String datapoint.
     String(DatapointString),
+    /// State datapoint.
+    State(DatapointState),
 }
 
 impl LatestDatapoint {
@@ -374,6 +433,14 @@ impl LatestDatapoint {
             _ => None,
         }
     }
+
+    /// Get the value of this as a state datapoint.
+    pub fn state(&self) -> Option<&DatapointState> {
+        match self {
+            Self::State(d) => Some(d),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -383,6 +450,10 @@ pub struct LatestDatapointsResponse {
     pub id: i64,
     /// Time series external ID.
     pub external_id: Option<String>,
+    /// Data modeling instance ID of the time series.
+    pub instance_id: Option<DmInstanceId>,
+    /// Time series value type.
+    pub r#type: Option<CoreTimeSeriesType>,
     /// Retrieved datapoints.
     pub datapoint: Option<LatestDatapoint>,
     /// The physical unit of the time series (free-text field).
@@ -409,6 +480,9 @@ struct DatapointsResponsePartial {
     datapoints: Value,
     unit: Option<String>,
     unit_external_id: Option<String>,
+    instance_id: Option<DmInstanceId>,
+    #[serde(rename = "type")]
+    time_series_type: Option<CoreTimeSeriesType>,
     #[serde(default)]
     is_step: bool,
     #[serde(default)]
@@ -428,7 +502,16 @@ impl<'de> Deserialize<'de> for LatestDatapointsResponse {
         } else if let Value::Array(v) = dps {
             match v.into_iter().next() {
                 Some(v) => {
-                    if r.is_string {
+                    if r.time_series_type == Some(CoreTimeSeriesType::State) {
+                        Some(LatestDatapoint::State(serde_json::from_value(v).map_err(
+                            |e| {
+                                D::Error::custom(format!(
+                                    "Failed to deserialize state datapoint: {e:?}"
+                                ))
+                            },
+                        )?))
+                    // Fall back to `is_string` when `type` is absent or unrecognized.
+                    } else if r.time_series_type == Some(CoreTimeSeriesType::String) || r.is_string {
                         Some(LatestDatapoint::String(serde_json::from_value(v).map_err(
                             |e| {
                                 D::Error::custom(format!(
@@ -455,6 +538,8 @@ impl<'de> Deserialize<'de> for LatestDatapointsResponse {
         Ok(Self {
             id: r.id,
             external_id: r.external_id,
+            instance_id: r.instance_id,
+            r#type: r.time_series_type,
             datapoint: dps,
             unit: r.unit,
             unit_external_id: r.unit_external_id,
@@ -574,6 +659,15 @@ impl From<TimeSeriesReference> for IdentityOrInstance {
     }
 }
 
+fn core_time_series_type(value: i32) -> Option<CoreTimeSeriesType> {
+    match proto::TimeSeriesType::try_from(value).ok()? {
+        proto::TimeSeriesType::TimeseriesTypeNumeric => Some(CoreTimeSeriesType::Numeric),
+        proto::TimeSeriesType::TimeseriesTypeString => Some(CoreTimeSeriesType::String),
+        proto::TimeSeriesType::TimeseriesTypeState => Some(CoreTimeSeriesType::State),
+        proto::TimeSeriesType::TimeseriesTypeUnspecified => None,
+    }
+}
+
 impl From<DataPointListItem> for DatapointsResponse {
     fn from(req: DataPointListItem) -> DatapointsResponse {
         DatapointsResponse {
@@ -583,6 +677,8 @@ impl From<DataPointListItem> for DatapointsResponse {
             } else {
                 Some(req.external_id)
             },
+            instance_id: req.instance_id.map(DmInstanceId::from),
+            r#type: core_time_series_type(req.r#type),
             unit: if req.unit.is_empty() {
                 None
             } else {
@@ -607,6 +703,15 @@ impl From<DataPointListItem> for DatapointsResponse {
                                 .datapoints
                                 .into_iter()
                                 .map(DatapointString::from)
+                                .collect(),
+                        )
+                    }
+                    data_point_list_item::DatapointType::StateDatapoints(state_dps) => {
+                        DatapointsEnumType::StateDatapoints(
+                            state_dps
+                                .datapoints
+                                .into_iter()
+                                .map(DatapointState::from)
                                 .collect(),
                         )
                     }
@@ -652,6 +757,13 @@ impl From<AddDatapoints> for DataPointInsertionItem {
                     self::proto::data_point_insertion_item::DatapointType::StringDatapoints(
                         StringDatapoints {
                             datapoints: dps.into_iter().map(StringDatapoint::from).collect(),
+                        },
+                    ),
+                ),
+                DatapointsEnumType::StateDatapoints(dps) => Some(
+                    self::proto::data_point_insertion_item::DatapointType::StateDatapoints(
+                        StateDatapoints {
+                            datapoints: dps.into_iter().map(StateDatapoint::from).collect(),
                         },
                     ),
                 ),

--- a/cognite/src/dto/core/datapoint/filter.rs
+++ b/cognite/src/dto/core/datapoint/filter.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use crate::{Identity, IdentityOrInstance};
+use crate::IdentityOrInstance;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -212,8 +212,8 @@ pub struct LatestDatapointsQuery {
     /// Default `true`
     pub treat_uncertain_as_bad: Option<bool>,
     #[serde(flatten)]
-    /// ID or external ID of time series to retrieve data from.
-    pub id: Identity,
+    /// ID, external ID or instance ID of time series to retrieve data from.
+    pub id: IdentityOrInstance,
 }
 
 impl LatestDatapointsQuery {
@@ -221,11 +221,14 @@ impl LatestDatapointsQuery {
     ///
     /// # Arguments
     ///
-    /// * `id` - Time series ID.
+    /// * `id` - Time series ID, external ID or instance ID.
     /// * `before` - Get data points before this time.
-    pub fn new(id: Identity, before: impl Into<String>) -> LatestDatapointsQuery {
+    pub fn new(
+        id: impl Into<IdentityOrInstance>,
+        before: impl Into<String>,
+    ) -> LatestDatapointsQuery {
         LatestDatapointsQuery {
-            id,
+            id: id.into(),
             before: Some(before.into()),
             target_unit: Default::default(),
             target_unit_system: Default::default(),

--- a/cognite/src/dto/core/datapoint/generated/com.cognite.v1.timeseries.proto.rs
+++ b/cognite/src/dto/core/datapoint/generated/com.cognite.v1.timeseries.proto.rs
@@ -38,7 +38,23 @@ pub struct StringDatapoints {
     #[prost(message, repeated, tag = "1")]
     pub datapoints: ::prost::alloc::vec::Vec<StringDatapoint>,
 }
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StateDatapoint {
+    #[prost(int64, tag = "1")]
+    pub timestamp: i64,
+    #[prost(int64, optional, tag = "2")]
+    pub numeric_value: ::core::option::Option<i64>,
+    #[prost(string, optional, tag = "3")]
+    pub string_value: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "4")]
+    pub status: ::core::option::Option<Status>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StateDatapoints {
+    #[prost(message, repeated, tag = "1")]
+    pub datapoints: ::prost::alloc::vec::Vec<StateDatapoint>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AggregateDatapoint {
     #[prost(int64, tag = "1")]
     pub timestamp: i64,
@@ -74,11 +90,30 @@ pub struct AggregateDatapoint {
     pub duration_uncertain: f64,
     #[prost(double, tag = "17")]
     pub duration_bad: f64,
+    #[prost(message, optional, tag = "18")]
+    pub max_datapoint: ::core::option::Option<NumericDatapoint>,
+    #[prost(message, optional, tag = "19")]
+    pub min_datapoint: ::core::option::Option<NumericDatapoint>,
+    #[prost(message, repeated, tag = "20")]
+    pub state_aggregates: ::prost::alloc::vec::Vec<StateAggregate>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AggregateDatapoints {
     #[prost(message, repeated, tag = "1")]
     pub datapoints: ::prost::alloc::vec::Vec<AggregateDatapoint>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StateAggregate {
+    #[prost(int64, tag = "1")]
+    pub numeric_value: i64,
+    #[prost(string, optional, tag = "2")]
+    pub string_value: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int64, optional, tag = "3")]
+    pub state_count: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "4")]
+    pub state_transitions: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "5")]
+    pub state_duration: ::core::option::Option<i64>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InstanceId {
@@ -95,7 +130,7 @@ pub struct DataPointInsertionItem {
     )]
     pub time_series_reference:
         ::core::option::Option<data_point_insertion_item::TimeSeriesReference>,
-    #[prost(oneof = "data_point_insertion_item::DatapointType", tags = "3, 4")]
+    #[prost(oneof = "data_point_insertion_item::DatapointType", tags = "3, 4, 6")]
     pub datapoint_type: ::core::option::Option<data_point_insertion_item::DatapointType>,
 }
 /// Nested message and enum types in `DataPointInsertionItem`.
@@ -115,6 +150,8 @@ pub mod data_point_insertion_item {
         NumericDatapoints(super::NumericDatapoints),
         #[prost(message, tag = "4")]
         StringDatapoints(super::StringDatapoints),
+        #[prost(message, tag = "6")]
+        StateDatapoints(super::StateDatapoints),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -140,7 +177,9 @@ pub struct DataPointListItem {
     pub next_cursor: ::prost::alloc::string::String,
     #[prost(string, tag = "10")]
     pub unit_external_id: ::prost::alloc::string::String,
-    #[prost(oneof = "data_point_list_item::DatapointType", tags = "3, 4, 5")]
+    #[prost(enumeration = "TimeSeriesType", tag = "12")]
+    pub r#type: i32,
+    #[prost(oneof = "data_point_list_item::DatapointType", tags = "3, 4, 5, 13")]
     pub datapoint_type: ::core::option::Option<data_point_list_item::DatapointType>,
 }
 /// Nested message and enum types in `DataPointListItem`.
@@ -153,10 +192,44 @@ pub mod data_point_list_item {
         StringDatapoints(super::StringDatapoints),
         #[prost(message, tag = "5")]
         AggregateDatapoints(super::AggregateDatapoints),
+        #[prost(message, tag = "13")]
+        StateDatapoints(super::StateDatapoints),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DataPointListResponse {
     #[prost(message, repeated, tag = "1")]
     pub items: ::prost::alloc::vec::Vec<DataPointListItem>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TimeSeriesType {
+    TimeseriesTypeUnspecified = 0,
+    TimeseriesTypeNumeric = 1,
+    TimeseriesTypeString = 2,
+    TimeseriesTypeState = 3,
+}
+impl TimeSeriesType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::TimeseriesTypeUnspecified => "TIMESERIES_TYPE_UNSPECIFIED",
+            Self::TimeseriesTypeNumeric => "TIMESERIES_TYPE_NUMERIC",
+            Self::TimeseriesTypeString => "TIMESERIES_TYPE_STRING",
+            Self::TimeseriesTypeState => "TIMESERIES_TYPE_STATE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "TIMESERIES_TYPE_UNSPECIFIED" => Some(Self::TimeseriesTypeUnspecified),
+            "TIMESERIES_TYPE_NUMERIC" => Some(Self::TimeseriesTypeNumeric),
+            "TIMESERIES_TYPE_STRING" => Some(Self::TimeseriesTypeString),
+            "TIMESERIES_TYPE_STATE" => Some(Self::TimeseriesTypeState),
+            _ => None,
+        }
+    }
 }

--- a/cognite/src/dto/core/time_series.rs
+++ b/cognite/src/dto/core/time_series.rs
@@ -15,6 +15,21 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+/// Time series value type.
+pub enum CoreTimeSeriesType {
+    /// Numeric time series.
+    Numeric,
+    /// String time series.
+    String,
+    /// State time series.
+    State,
+    /// A time series type not yet known to this SDK version.
+    #[serde(other)]
+    Unknown,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 /// A CDF time series.
@@ -30,6 +45,9 @@ pub struct TimeSeries {
     pub name: Option<String>,
     /// Whether this is a time series for string or double data points.
     pub is_string: bool,
+    /// Time series value type.
+    #[serde(default)]
+    pub r#type: Option<CoreTimeSeriesType>,
     /// Custom, application specific metadata. String key -> String value.
     /// Maximum length of key is 128 bytes, up to 256 key-value pairs,
     /// of total size of at most 10000 bytes across all keys and values.

--- a/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
+++ b/cognite/src/dto/data_modeling/instances/extensions/timeseries.rs
@@ -20,6 +20,8 @@ pub enum TimeSeriesType {
     #[default]
     /// Indicates that timeseries type is a number.
     Numeric,
+    /// Indicates that timeseries type is a state.
+    State,
 }
 
 #[skip_serializing_none]
@@ -45,6 +47,8 @@ pub struct Timeseries {
     pub activities: Option<Vec<InstanceId>>,
     /// Type of datapoints the time series contains.
     pub r#type: TimeSeriesType,
+    /// State set used for validating state time series data points.
+    pub state_set: Option<InstanceId>,
 }
 
 impl Timeseries {

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -3,10 +3,73 @@
 #[cfg(test)]
 use cognite::time_series::*;
 use cognite::*;
+use models::instances::{
+    CogniteExtendable, CogniteTimeseries, InstanceId, NodeAndEdgeCreateCollection,
+    NodeOrEdgeCreate, NodeOrEdgeSpecification, TimeSeriesType, Timeseries, WithInstance, WithView,
+};
+use models::ItemId;
 
 mod common;
 pub use common::*;
 use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct StateSetState {
+    numeric_value: i32,
+    string_value: String,
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct CogniteStateSetProperties {
+    name: Option<String>,
+    states: Vec<StateSetState>,
+}
+
+impl WithView for CogniteStateSetProperties {
+    const SPACE: &'static str = "cdf_cdm";
+    const EXTERNAL_ID: &'static str = "CogniteStateSet";
+    const VERSION: &'static str = "v1";
+}
+
+type CogniteStateSet = CogniteExtendable<CogniteStateSetProperties>;
+
+async fn beta_upsert_instances<TProperties>(
+    client: &CogniteClient,
+    items: Vec<NodeOrEdgeCreate<TProperties>>,
+) -> cognite::Result<()>
+where
+    TProperties: Serialize + Send + Sync,
+{
+    let collection = NodeAndEdgeCreateCollection {
+        items,
+        auto_create_direct_relations: Some(true),
+        ..Default::default()
+    };
+    client
+        .api_client
+        .clone_with_api_version("beta")
+        .post::<::serde_json::Value, _>("models/instances", &collection)
+        .await?;
+    Ok(())
+}
+
+async fn beta_delete_instances(
+    client: &CogniteClient,
+    items: &[NodeOrEdgeSpecification],
+) -> cognite::Result<()> {
+    client
+        .api_client
+        .clone_with_api_version("beta")
+        .post::<::serde_json::Value, _>("models/instances/delete", &Items::new(items))
+        .await?;
+    Ok(())
+}
 
 async fn create_test_ts(client: &CogniteClient, is_string: bool, idx: i32) -> TimeSeries {
     let ts = AddTimeSeries {
@@ -203,6 +266,175 @@ async fn create_retrieve_delete_string_datapoints() {
 }
 
 #[tokio::test]
+async fn create_retrieve_latest_delete_state_datapoints() {
+    let space = std::env::var("CORE_DM_TEST_SPACE")
+        .expect("CORE_DM_TEST_SPACE must be set to a writable data modeling space");
+    let state_set_external_id = format!("{}-state-set", uuid::Uuid::new_v4());
+    let ts_external_id = format!("{}-state-ts", uuid::Uuid::new_v4());
+    let client = get_client();
+
+    let state_set = CogniteStateSet::new(
+        space.clone(),
+        state_set_external_id.clone(),
+        CogniteStateSetProperties {
+            name: Some("Rust SDK state datapoint test states".to_string()),
+            states: vec![
+                StateSetState {
+                    numeric_value: 0,
+                    string_value: "OFF".to_string(),
+                },
+                StateSetState {
+                    numeric_value: 1,
+                    string_value: "RUNNING".to_string(),
+                },
+                StateSetState {
+                    numeric_value: 2,
+                    string_value: "STANDBY".to_string(),
+                },
+            ],
+            ..Default::default()
+        },
+    );
+    beta_upsert_instances(&client, vec![state_set.instance()])
+        .await
+        .unwrap();
+
+    let mut timeseries =
+        CogniteTimeseries::new(space.clone(), ts_external_id.clone(), Timeseries::new(true));
+    timeseries.properties.r#type = TimeSeriesType::State;
+    timeseries.properties.state_set = Some(InstanceId {
+        space: space.clone(),
+        external_id: state_set_external_id.clone(),
+    });
+    beta_upsert_instances(&client, vec![timeseries.instance()])
+        .await
+        .unwrap();
+
+    let ts_instance_id = InstanceId {
+        space: space.clone(),
+        external_id: ts_external_id.clone(),
+    };
+    let start = 1_735_689_600_000;
+
+    client
+        .time_series
+        .insert_datapoints(vec![AddDatapoints {
+            id: ts_instance_id.clone().into(),
+            datapoints: DatapointsEnumType::StateDatapoints(vec![
+                DatapointState {
+                    timestamp: start,
+                    numeric_value: Some(0),
+                    string_value: Some("OFF".to_string()),
+                    status: None,
+                },
+                DatapointState {
+                    timestamp: start + 3_600_000,
+                    numeric_value: Some(1),
+                    string_value: Some("RUNNING".to_string()),
+                    status: None,
+                },
+                DatapointState {
+                    timestamp: start + 7_200_000,
+                    numeric_value: Some(2),
+                    string_value: Some("STANDBY".to_string()),
+                    status: None,
+                },
+            ]),
+        }])
+        .await
+        .unwrap();
+
+    let raw = client
+        .time_series
+        .retrieve_datapoints(&DatapointsFilter {
+            items: vec![DatapointsQuery {
+                id: ts_instance_id.clone().into(),
+                limit: Some(10),
+                ..Default::default()
+            }],
+            start: Some(start.into()),
+            end: Some((start + 10_800_000).into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let raw_response = raw.into_iter().next().unwrap();
+    assert_eq!(Some(CoreTimeSeriesType::State), raw_response.r#type);
+    assert_eq!(Some(ts_instance_id.clone()), raw_response.instance_id);
+    let raw_states = raw_response.datapoints.state().unwrap();
+    assert_eq!(3, raw_states.len());
+    assert_eq!(Some(0), raw_states[0].numeric_value);
+    assert_eq!(Some("OFF".to_string()), raw_states[0].string_value);
+    assert_eq!(Some(1), raw_states[1].numeric_value);
+    assert_eq!(Some("RUNNING".to_string()), raw_states[1].string_value);
+
+    let latest = client
+        .time_series
+        .retrieve_latest_datapoints(
+            &[LatestDatapointsQuery {
+                id: ts_instance_id.clone().into(),
+                before: Some((start + 10_800_000).to_string()),
+                ..Default::default()
+            }],
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(Some(CoreTimeSeriesType::State), latest[0].r#type);
+    assert_eq!(Some(ts_instance_id.clone()), latest[0].instance_id);
+    let latest_state = latest[0].datapoint.as_ref().unwrap().state().unwrap();
+    assert_eq!(Some(2), latest_state.numeric_value);
+    assert_eq!(Some("STANDBY".to_string()), latest_state.string_value);
+
+    client
+        .time_series
+        .delete_datapoints(&[DeleteDatapointsQuery::new(
+            ts_instance_id.clone(),
+            start,
+            start + 10_800_000,
+        )])
+        .await
+        .unwrap();
+
+    let raw_after_delete = client
+        .time_series
+        .retrieve_datapoints(&DatapointsFilter {
+            items: vec![DatapointsQuery {
+                id: ts_instance_id.clone().into(),
+                limit: Some(10),
+                ..Default::default()
+            }],
+            start: Some(start.into()),
+            end: Some((start + 10_800_000).into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let deleted_states = raw_after_delete
+        .into_iter()
+        .next()
+        .map(|response| response.datapoints.state().unwrap_or_default())
+        .unwrap_or_default();
+    assert!(deleted_states.is_empty());
+
+    let _ = beta_delete_instances(
+        &client,
+        &[
+            NodeOrEdgeSpecification::Node(ItemId {
+                space: space.clone(),
+                external_id: ts_external_id,
+            }),
+            NodeOrEdgeSpecification::Node(ItemId {
+                space,
+                external_id: state_set_external_id,
+            }),
+        ],
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn retrieve_latest() {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -237,7 +469,7 @@ async fn retrieve_latest() {
         .retrieve_latest_datapoints(
             &[LatestDatapointsQuery {
                 before: Some(format!("{}", start + 200_000)),
-                id: Identity::Id { id: ts.id },
+                id: Identity::Id { id: ts.id }.into(),
                 ..Default::default()
             }],
             false,
@@ -337,7 +569,7 @@ async fn create_retrieve_double_datapoints_with_status() {
                 before: Some((start + 10000).to_string()),
                 include_status: Some(true),
                 ignore_bad_data_points: Some(false),
-                id: Identity::from(ts.id),
+                id: Identity::from(ts.id).into(),
                 ..Default::default()
             }],
             false,

--- a/cognite/tests/datapoints_tests.rs
+++ b/cognite/tests/datapoints_tests.rs
@@ -318,7 +318,7 @@ async fn create_retrieve_latest_delete_state_datapoints() {
 
     client
         .time_series
-        .insert_datapoints(vec![AddDatapoints {
+        .insert_datapoints_beta(vec![AddDatapoints {
             id: ts_instance_id.clone().into(),
             datapoints: DatapointsEnumType::StateDatapoints(vec![
                 DatapointState {
@@ -346,7 +346,7 @@ async fn create_retrieve_latest_delete_state_datapoints() {
 
     let raw = client
         .time_series
-        .retrieve_datapoints(&DatapointsFilter {
+        .retrieve_datapoints_beta(&DatapointsFilter {
             items: vec![DatapointsQuery {
                 id: ts_instance_id.clone().into(),
                 limit: Some(10),
@@ -371,7 +371,7 @@ async fn create_retrieve_latest_delete_state_datapoints() {
 
     let latest = client
         .time_series
-        .retrieve_latest_datapoints(
+        .retrieve_latest_datapoints_beta(
             &[LatestDatapointsQuery {
                 id: ts_instance_id.clone().into(),
                 before: Some((start + 10_800_000).to_string()),
@@ -389,7 +389,7 @@ async fn create_retrieve_latest_delete_state_datapoints() {
 
     client
         .time_series
-        .delete_datapoints(&[DeleteDatapointsQuery::new(
+        .delete_datapoints_beta(&[DeleteDatapointsQuery::new(
             ts_instance_id.clone(),
             start,
             start + 10_800_000,
@@ -399,7 +399,7 @@ async fn create_retrieve_latest_delete_state_datapoints() {
 
     let raw_after_delete = client
         .time_series
-        .retrieve_datapoints(&DatapointsFilter {
+        .retrieve_datapoints_beta(&DatapointsFilter {
             items: vec![DatapointsQuery {
                 id: ts_instance_id.clone().into(),
                 limit: Some(10),


### PR DESCRIPTION
This adds support for state time series in the Rust SDK

It adds raw state datapoint support for the beta time series datapoints APIs:
- insert state datapoints
- retrieve raw state datapoints
- retrieve latest state datapoints
- delete datapoints by instance id

Since state time series is a beta CDF feature, these are exposed via new `_beta`-suffixed methods (`insert_datapoints_beta`, `retrieve_datapoints_beta`, `retrieve_latest_datapoints_beta`, `delete_datapoints_beta`, plus `_proto_beta` variants) rather than the existing stable datapoint methods. The `_beta` methods are intended to be removed and folded back into the stable methods once state time series is generally available.

The PR also updates the protobuf definitions/generated types, exposes the time series `type` on relevant responses, allows latest datapoint queries by instance id, and adds a data modeling time series `stateSet` reference.

An integration test covers creating a state set and state time series, inserting state datapoints, reading raw/latest values, and deleting them again.

The next PR will add the remaining state time series features, including aggregate support (`stateCount`, `stateDuration`, `stateTransitions`/`stateAggregates`) and the remaining SDK surfaces that still do not handle state datapoints, such as datapoint streaming/subscription handling.