### PR TITLE
chore: pin GitHub Actions to commit SHAs via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "local>cognitedata/renovate-config-public"
   ],
-  "rangeStrategy": "replace"
+  "rangeStrategy": "replace",
+  "pinDigests": true
 }


### PR DESCRIPTION
Enable digest pinning for GitHub Actions in Renovate

GitHub Actions version tags (e.g. actions/checkout@v7) are mutable — the tag can be moved to a different commit at any time, meaning a workflow can silently change behavior or introduce a supply chain risk without any code change on our side.

Adding "pinDigests": true tells Renovate to pin all GitHub Actions to their full commit SHA (e.g. actions/checkout@9c091bb... # v7.0.0). Renovate will then keep those SHAs up to date automatically as new releases come out, so we get immutability without the maintenance burden.