### PR TITLE
Pin rust version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get install protobuf-compiler
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          # toolchain: --> see rust-toolchain.toml
           components: rustfmt, clippy
       - name: Run clippy
         run: cargo clippy -- -D warnings
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          # toolchain: --> see rust-toolchain.toml
           target: wasm32-unknown-unknown
       - name: Compile library
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        # toolchain: --> see rust-toolchain.toml
 
       - name: Create tag
         uses: rickstaa/action-create-tag@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["cognite", "cognite-codegen"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.96"
+
 [workspace.lints.rust]
 
 [workspace.lints.clippy]

--- a/cognite/Cargo.toml
+++ b/cognite/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/cognitedata/cognite-sdk-rust"
 description = "SDK for the Cognite Data Fusion API"
 license = "Apache-2.0"
 edition = "2021"
+rust-version.workspace = true
 publish = true
 documentation = "https://docs.rs/cognite-sdk/"
 readme = "README.md"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Latest master run used 1.96.0 https://github.com/cognitedata/cognite-sdk-rust/actions/runs/28349270025/job/83978719490

An unrelated renovate PR https://github.com/cognitedata/cognite-sdk-rust/pull/351 failed because of new lints https://github.com/cognitedata/cognite-sdk-rust/actions/runs/29806225109/job/88557219793?pr=351

Let's pin rust toolchain and let renovate suggest updates, in this case it'd need manual work to be buildable which is fine

Also actions-rs is archived, for release switching to same action as in build&test